### PR TITLE
fix varioius type hinting issues

### DIFF
--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 
 import pytest
@@ -34,3 +35,11 @@ async def test_wrong_injection() -> None:
 
     with pytest.raises(RuntimeError, match="Injected arguments must not be redefined"):
         await inner(_=container.SimpleFactory(dep1="1", dep2=2))
+
+
+def test_type_check() -> None:
+    @inject
+    async def main() -> None:
+        pass
+
+    asyncio.run(main())

--- a/that_depends/__init__.py
+++ b/that_depends/__init__.py
@@ -1,3 +1,4 @@
+from that_depends import providers
 from that_depends.container import BaseContainer
 from that_depends.injection import Provide, inject
 

--- a/that_depends/container.py
+++ b/that_depends/container.py
@@ -45,7 +45,7 @@ class BaseContainer:
         return _inner
 
     @classmethod
-    async def resolve(cls, object_to_resolve: type[T] | typing.Callable[P, T]) -> T:
+    async def resolve(cls, object_to_resolve: type[T] | typing.Callable[..., T]) -> T:
         signature = inspect.signature(object_to_resolve)
         kwargs = {}
         providers = cls.get_providers()

--- a/that_depends/injection.py
+++ b/that_depends/injection.py
@@ -9,7 +9,9 @@ P = typing.ParamSpec("P")
 T = typing.TypeVar("T")
 
 
-def inject(func: typing.Callable[P, typing.Awaitable[T]]) -> typing.Callable[P, typing.Awaitable[T]]:
+def inject(
+    func: typing.Callable[P, typing.Coroutine[typing.Any, typing.Any, T]],
+) -> typing.Callable[P, typing.Coroutine[typing.Any, typing.Any, T]]:
     signature = inspect.signature(func)
 
     @functools.wraps(func)

--- a/that_depends/providers/base.py
+++ b/that_depends/providers/base.py
@@ -3,20 +3,22 @@ import typing
 
 
 T = typing.TypeVar("T")
+R = typing.TypeVar("R")
+T_co = typing.TypeVar("T_co", covariant=True)
 
 
-class AbstractProvider(typing.Generic[T], abc.ABC):
+class AbstractProvider(typing.Generic[T_co], abc.ABC):
     """Abstract Provider Class."""
 
     @abc.abstractmethod
-    async def async_resolve(self) -> T:
+    async def async_resolve(self) -> T_co:
         """Resolve dependency asynchronously."""
 
     @abc.abstractmethod
-    def sync_resolve(self) -> T:
+    def sync_resolve(self) -> T_co:
         """Resolve dependency synchronously."""
 
-    async def __call__(self) -> T:
+    async def __call__(self) -> T_co:
         return await self.async_resolve()
 
     def override(self, mock: object) -> None:

--- a/that_depends/providers/collections.py
+++ b/that_depends/providers/collections.py
@@ -6,15 +6,15 @@ from that_depends.providers.base import AbstractProvider
 T = typing.TypeVar("T")
 
 
-class List(AbstractProvider[T]):
+class List(AbstractProvider[list[T]]):
     def __init__(self, *providers: AbstractProvider[T]) -> None:
         self._providers = providers
 
-    async def async_resolve(self) -> list[T]:  # type: ignore[override]
+    async def async_resolve(self) -> list[T]:
         return [await x.async_resolve() for x in self._providers]
 
-    def sync_resolve(self) -> list[T]:  # type: ignore[override]
+    def sync_resolve(self) -> list[T]:
         return [x.sync_resolve() for x in self._providers]
 
-    async def __call__(self) -> list[T]:  # type: ignore[override]
+    async def __call__(self) -> list[T]:
         return await self.async_resolve()

--- a/that_depends/providers/resources.py
+++ b/that_depends/providers/resources.py
@@ -12,7 +12,7 @@ P = typing.ParamSpec("P")
 class Resource(AbstractResource[T]):
     def __init__(
         self,
-        creator: typing.Callable[..., typing.Iterator[T]],
+        creator: typing.Callable[P, typing.Iterator[T]],
         *args: P.args,
         **kwargs: P.kwargs,
     ) -> None:


### PR DESCRIPTION
Hi! I discovered this project this week, and I am currently considering it as a replacement to `dependency-injector`. Thank you for creating it.

This PR contains type hinting fixes for some issues that I have detected while testing `that-depends` on my codebase, running both `mypy` and `pyright`. Please read the inline comments for more details and let me know what you think.