### PR TITLE
add cast property to AbstractProvider

### DIFF
--- a/tests/container.py
+++ b/tests/container.py
@@ -30,8 +30,8 @@ class SimpleFactory:
     dep2: int
 
 
-async def async_factory() -> datetime.datetime:
-    return datetime.datetime.now(tz=datetime.timezone.utc)
+async def async_factory(now: datetime.datetime) -> datetime.datetime:
+    return now + datetime.timedelta(hours=1)
 
 
 @dataclasses.dataclass(kw_only=True, slots=True)
@@ -58,11 +58,11 @@ class DIContainer(BaseContainer):
     sequence = providers.List(sync_resource, async_resource)
 
     simple_factory = providers.Factory(SimpleFactory, dep1="text", dep2=123)
-    async_factory = providers.AsyncFactory(async_factory)
+    async_factory = providers.AsyncFactory(async_factory, async_resource.cast)
     dependent_factory = providers.Factory(
         DependentFactory,
-        simple_factory=simple_factory,
-        sync_resource=sync_resource,
-        async_resource=async_resource,
+        simple_factory=simple_factory.cast,
+        sync_resource=sync_resource.cast,
+        async_resource=async_resource.cast,
     )
     singleton = providers.Singleton(SingletonFactory, dep1=True)

--- a/that_depends/providers/base.py
+++ b/that_depends/providers/base.py
@@ -27,6 +27,23 @@ class AbstractProvider(typing.Generic[T_co], abc.ABC):
     def reset_override(self) -> None:
         self._override = None
 
+    @property
+    def cast(self) -> T_co:
+        """Returns self, but cast to the type of the provided value.
+
+        This helps to pass providers as input to other providers while avoiding type checking errors:
+
+            class A: ...
+
+            def create_b(a: A) -> B: ...
+
+            class Container(BaseContainer):
+                a_factory = Factory(A)
+                b_factory1 = Factory(create_b, a_factory)  # works, but mypy (or pyright, etc.) will complain
+                b_factory2 = Factory(create_b, a_factory.cast)  # works and passes type checking
+        """
+        return typing.cast(T_co, self)
+
 
 class AbstractResource(AbstractProvider[T], abc.ABC):
     """Abstract Resource Class."""


### PR DESCRIPTION
Fixes https://github.com/modern-python/that-depends/issues/17