### PR TITLE
Bugfix/inject and lock

### DIFF
--- a/that_depends/injection.py
+++ b/that_depends/injection.py
@@ -9,23 +9,11 @@ P = typing.ParamSpec("P")
 T = typing.TypeVar("T")
 
 
-@typing.overload
-def inject(
-    func: typing.Callable[P, typing.Coroutine[typing.Any, typing.Any, T]],
-) -> typing.Callable[P, typing.Coroutine[typing.Any, typing.Any, T]]: ...
-
-
-@typing.overload
 def inject(
     func: typing.Callable[P, T],
-) -> typing.Callable[P, T]: ...
-
-
-def inject(
-    func: typing.Callable[P, typing.Any],
-) -> typing.Callable[P, typing.Any]:
+) -> typing.Callable[P, T]:
     if inspect.iscoroutinefunction(func):
-        return _inject_to_async(func)
+        return typing.cast(typing.Callable[P, T], _inject_to_async(func))
 
     return _inject_to_sync(func)
 

--- a/that_depends/providers/singleton.py
+++ b/that_depends/providers/singleton.py
@@ -1,3 +1,4 @@
+import asyncio
 import typing
 
 from that_depends.providers.base import AbstractProvider
@@ -14,20 +15,22 @@ class Singleton(AbstractProvider[T]):
         self._kwargs = kwargs
         self._override = None
         self._instance: T | None = None
+        self._resolving_lock = asyncio.Lock()
 
     async def async_resolve(self) -> T:
         if self._override is not None:
             return typing.cast(T, self._override)
 
-        if self._instance is None:
-            self._instance = self._factory(
-                *[await x.async_resolve() if isinstance(x, AbstractProvider) else x for x in self._args],
-                **{
-                    k: await v.async_resolve() if isinstance(v, AbstractProvider) else v
-                    for k, v in self._kwargs.items()
-                },
-            )
-        return self._instance
+        async with self._resolving_lock:
+            if self._instance is None:
+                self._instance = self._factory(
+                    *[await x.async_resolve() if isinstance(x, AbstractProvider) else x for x in self._args],
+                    **{
+                        k: await v.async_resolve() if isinstance(v, AbstractProvider) else v
+                        for k, v in self._kwargs.items()
+                    },
+                )
+            return self._instance
 
     def sync_resolve(self) -> T:
         if self._override is not None:


### PR DESCRIPTION
1. Simplify `inject` method: remove overloading
2. Add asyncio.Lock to singleton and resources in order to prevent race condition