### PR TITLE
Export `container_context` from `that_depends`

### DIFF
--- a/that_depends/__init__.py
+++ b/that_depends/__init__.py
@@ -1,7 +1,7 @@
 from that_depends import providers
-from that_depends.providers import container_context
 from that_depends.container import BaseContainer
 from that_depends.injection import Provide, inject
+from that_depends.providers import container_context
 
 
 __all__ = ["container_context", "providers", "BaseContainer", "inject", "Provide"]

--- a/that_depends/__init__.py
+++ b/that_depends/__init__.py
@@ -1,6 +1,7 @@
 from that_depends import providers
+from that_depends.providers import container_context
 from that_depends.container import BaseContainer
 from that_depends.injection import Provide, inject
 
 
-__all__ = ["providers", "BaseContainer", "inject", "Provide"]
+__all__ = ["container_context", "providers", "BaseContainer", "inject", "Provide"]


### PR DESCRIPTION
I often forget to enter container context when using context resources. When I do, it annoyes me to have to jump up to imports block and add `import that_depends.providers` manually. To prevent that, I suggest making it available as `that_depends.container_context()`.
