### PR TITLE
Add a new class DictProvider to handle a dictionary of values.

### DIFF
--- a/docs/providers/dict.md
+++ b/docs/providers/dict.md
@@ -1,0 +1,51 @@
+
+# DictProvider
+- It allows you to logically group related dependencies together in a dictionary, making it easier to manage and inject them as a single unit.
+- It simplifies the injection process when multiple dependencies need to be passed to a component that expects a dictionary of dependencies.
+
+## Example Usage
+### Step 1: Define the Dependencies
+```python
+@dataclasses.dataclass(kw_only=True, slots=True)
+class ModuleA:
+    dependency: str
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class ModuleB:
+    dependency: str
+
+
+@dataclasses.dataclass(kw_only=True, slots=True)
+class Dispatcher:
+    modules: Dict[str, Any]
+
+```
+### Step 2: Define Providers
+Next, define the providers for these dependencies using `Factory` and `DictProvider`.
+
+```python
+class DIContainer(BaseContainer):
+    module_a_provider = providers.Factory(ModuleA, dependency="some_dependency_a")
+    module_b_provider = providers.Factory(ModuleB, dependency="some_dependency_b")
+    modules_provider = providers.DictProvider(module1=module_a_provider, module2=module_b_provider)
+    dispatcher_provider = providers.Factory(Dispatcher, modules=modules_provider)
+```
+
+### Step 3: Resolve the Dispatcher
+```
+dispatcher = DIContainer.dispatcher_provider.sync_resolve()
+
+print(dispatcher.modules["module1"].dependency)  # Output: some_dependency_a
+print(dispatcher.modules["module2"].dependency)  # Output: some_dependency_b
+
+# Asynchronous usage example
+import asyncio
+
+async def main():
+    dispatcher_async = await container.dispatcher_provider.async_resolve()
+    print(dispatcher_async.modules["module1"].dependency)  # Output: real_dependency_a
+    print(dispatcher_async.modules["module2"].dependency)  # Output: real_dependency_b
+
+asyncio.run(main())
+```

--- a/that_depends/providers/__init__.py
+++ b/that_depends/providers/__init__.py
@@ -1,5 +1,5 @@
 from that_depends.providers.base import AbstractProvider, AbstractResource
-from that_depends.providers.collections import List
+from that_depends.providers.collections import DictProvider, List
 from that_depends.providers.context_resources import (
     AsyncContextResource,
     ContextResource,
@@ -26,4 +26,5 @@ __all__ = [
     "Selector",
     "Singleton",
     "container_context",
+    "DictProvider",
 ]

--- a/that_depends/providers/collections.py
+++ b/that_depends/providers/collections.py
@@ -18,3 +18,16 @@ class List(AbstractProvider[list[T]]):
 
     async def __call__(self) -> list[T]:
         return await self.async_resolve()
+
+
+class DictProvider(AbstractProvider[dict[str, T]]):
+    """Dictionary Provider Class."""
+
+    def __init__(self, **providers: AbstractProvider[T]) -> None:
+        self._providers = providers
+
+    async def async_resolve(self) -> dict[str, T]:
+        return {key: await provider.async_resolve() for key, provider in self._providers.items()}
+
+    def sync_resolve(self) -> dict[str, T]:
+        return {key: provider.sync_resolve() for key, provider in self._providers.items()}


### PR DESCRIPTION
MR adds a new class `DictProvider` to the codebase, which allows for handling dictionary values and resolving them asynchronously or synchronously.

Issue: https://github.com/modern-python/that-depends/issues/29