### PR TITLE
Raise for empty injections set with decorator

### DIFF
--- a/tests/providers/test_context_resources.py
+++ b/tests/providers/test_context_resources.py
@@ -4,7 +4,7 @@ import typing
 
 import pytest
 
-from that_depends import BaseContainer, inject, providers
+from that_depends import BaseContainer, providers
 from that_depends.providers import container_context
 
 
@@ -84,7 +84,6 @@ async def test_context_resource_included_context(
     assert context_resource_instance1 is context_resource_instance3
 
 
-@inject
 async def test_context_resources_overriding(context_resource: providers.AbstractResource[datetime.datetime]) -> None:
     context_resource_mock = datetime.datetime.now(tz=datetime.timezone.utc)
     context_resource.override(context_resource_mock)

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -36,6 +36,15 @@ async def test_wrong_injection() -> None:
         await inner(_=container.SimpleFactory(dep1="1", dep2=2))
 
 
+async def test_empty_injection() -> None:
+    @inject
+    async def inner(_: int) -> None:
+        """Do nothing."""
+
+    with pytest.raises(RuntimeError, match="Expected injection, but nothing found. Remove @inject decorator."):
+        await inner(1)
+
+
 @inject
 def test_sync_injection(
     fixture_one: int,
@@ -58,9 +67,18 @@ def test_wrong_sync_injection() -> None:
         inner(_=container.SimpleFactory(dep1="1", dep2=2))
 
 
+def test_sync_empty_injection() -> None:
+    @inject
+    def inner(_: int) -> None:
+        """Do nothing."""
+
+    with pytest.raises(RuntimeError, match="Expected injection, but nothing found. Remove @inject decorator."):
+        inner(1)
+
+
 def test_type_check() -> None:
     @inject
-    async def main() -> None:
-        pass
+    async def main(simple_factory: container.SimpleFactory = Provide[container.DIContainer.simple_factory]) -> None:
+        assert simple_factory
 
     asyncio.run(main())


### PR DESCRIPTION
If injection set with decorator have no references in function declaration `that-depends` will raise in order to remove unnecessary `@inject` decorator.