### PR TITLE
#72 Support sync container context.

### DIFF
--- a/tests/providers/test_context_resources.py
+++ b/tests/providers/test_context_resources.py
@@ -7,6 +7,7 @@ import pytest
 
 from that_depends import BaseContainer, fetch_context_item, providers
 from that_depends.providers import container_context
+from that_depends.providers.base import ResourceContext
 
 
 logger = logging.getLogger(__name__)
@@ -46,6 +47,13 @@ async def _clear_di_container() -> typing.AsyncIterator[None]:
 def context_resource(request: pytest.FixtureRequest) -> providers.ContextResource[str]:
     return typing.cast(providers.ContextResource[str], request.param)
 
+@pytest.fixture
+def sync_context_resource() -> providers.ContextResource[str]:
+    return DIContainer.sync_context_resource
+
+@pytest.fixture
+def async_context_resource() -> providers.ContextResource[str]:
+    return DIContainer.async_context_resource
 
 async def test_context_resource_without_context_init(
     context_resource: providers.ContextResource[str],
@@ -63,6 +71,18 @@ async def test_context_resource(context_resource: providers.ContextResource[str]
 
     assert await context_resource() is context_resource_result
 
+@container_context()
+def test_sync_context_resource(sync_context_resource: providers.ContextResource[str]) -> None:
+    context_resource_result = sync_context_resource.sync_resolve()
+
+    assert sync_context_resource.sync_resolve() is context_resource_result
+    
+async def test_async_context_resource_in_sync_context(async_context_resource: providers.ContextResource[str]) -> None:
+    
+
+    with pytest.raises(RuntimeError, match="Cannot tear down async context in sync mode"):
+        with container_context():
+            await async_context_resource()
 
 async def test_context_resource_different_context(
     context_resource: providers.ContextResource[datetime.datetime],
@@ -122,3 +142,18 @@ async def test_context_resource_with_dynamic_resource() -> None:
 
     async with container_context():
         assert (await DIContainer.dynamic_context_resource()).startswith("sync")
+        
+
+
+async def test_early_exit_of_container_context() -> None:
+    with pytest.raises(RuntimeError, match="Context is not set, call ``__aenter__`` first"):
+        await container_context().__aexit__(None, None, None)
+    with pytest.raises(RuntimeError, match="Context is not set, call ``__enter__`` first"):
+        container_context().__exit__(None, None, None)
+
+
+async def test_resource_context_early_teardown() -> None:
+    context = ResourceContext()
+    assert context.context_stack is None
+    context.sync_tear_down()
+    assert context.context_stack is None

--- a/tests/providers/test_context_resources.py
+++ b/tests/providers/test_context_resources.py
@@ -47,13 +47,16 @@ async def _clear_di_container() -> typing.AsyncIterator[None]:
 def context_resource(request: pytest.FixtureRequest) -> providers.ContextResource[str]:
     return typing.cast(providers.ContextResource[str], request.param)
 
+
 @pytest.fixture
 def sync_context_resource() -> providers.ContextResource[str]:
     return DIContainer.sync_context_resource
 
+
 @pytest.fixture
 def async_context_resource() -> providers.ContextResource[str]:
     return DIContainer.async_context_resource
+
 
 async def test_context_resource_without_context_init(
     context_resource: providers.ContextResource[str],
@@ -71,18 +74,18 @@ async def test_context_resource(context_resource: providers.ContextResource[str]
 
     assert await context_resource() is context_resource_result
 
+
 @container_context()
 def test_sync_context_resource(sync_context_resource: providers.ContextResource[str]) -> None:
     context_resource_result = sync_context_resource.sync_resolve()
 
     assert sync_context_resource.sync_resolve() is context_resource_result
-    
-async def test_async_context_resource_in_sync_context(async_context_resource: providers.ContextResource[str]) -> None:
-    
 
-    with pytest.raises(RuntimeError, match="Cannot tear down async context in sync mode"):
-        with container_context():
-            await async_context_resource()
+
+async def test_async_context_resource_in_sync_context(async_context_resource: providers.ContextResource[str]) -> None:
+    with pytest.raises(RuntimeError, match="Cannot tear down async context in sync mode"), container_context():
+        await async_context_resource()
+
 
 async def test_context_resource_different_context(
     context_resource: providers.ContextResource[datetime.datetime],
@@ -142,7 +145,6 @@ async def test_context_resource_with_dynamic_resource() -> None:
 
     async with container_context():
         assert (await DIContainer.dynamic_context_resource()).startswith("sync")
-        
 
 
 async def test_early_exit_of_container_context() -> None:
@@ -153,7 +155,7 @@ async def test_early_exit_of_container_context() -> None:
 
 
 async def test_resource_context_early_teardown() -> None:
-    context = ResourceContext()
+    context: ResourceContext[str] = ResourceContext()
     assert context.context_stack is None
     context.sync_tear_down()
     assert context.context_stack is None

--- a/that_depends/providers/context_resources.py
+++ b/that_depends/providers/context_resources.py
@@ -1,9 +1,10 @@
 import contextlib
+from functools import wraps
 import logging
 import typing
 import uuid
 import warnings
-from contextvars import ContextVar
+from contextvars import ContextVar, Token
 
 from that_depends.providers.base import AbstractResource, ResourceContext
 
@@ -19,7 +20,7 @@ Receive = typing.Callable[[], typing.Awaitable[Message]]
 Send = typing.Callable[[Message], typing.Awaitable[None]]
 ASGIApp = typing.Callable[[Scope, Receive, Send], typing.Awaitable[None]]
 
-
+"""
 @contextlib.asynccontextmanager
 async def container_context(initial_context: dict[str, typing.Any] | None = None) -> typing.AsyncIterator[None]:
     token: typing.Final = context_var.set(initial_context or {})
@@ -32,6 +33,44 @@ async def container_context(initial_context: dict[str, typing.Any] | None = None
                     await context_item.tear_down()
         finally:
             context_var.reset(token)
+"""
+
+
+class AsyncContextDecorator(object):
+    "A base class or mixin that enables async context managers to work as decorators."
+
+    def _recreate_cm(self):
+        """Return a recreated instance of self.
+        """
+        return self
+
+    def __call__(self, func):
+        @wraps(func)
+        async def inner(*args, **kwds):
+            async with self._recreate_cm():
+                return await func(*args, **kwds)
+        return inner
+
+
+ContextType = typing.TypeVar("ContextType", bound=typing.Dict[str, typing.Any])
+class container_context(contextlib.AbstractAsyncContextManager[ContextType], AsyncContextDecorator):
+    def __init__(self, initial_context: typing.Optional[ContextType] = None) -> None:
+        
+        self._initial_context: typing.Final[ContextType] = initial_context
+        self._context_token: typing.Optional[Token[ContextType]] = None
+
+    async def __aenter__(self) -> ContextType:
+        self._context_token = context_var.set(self._initial_context or {})
+        return context_var.get()
+
+
+    async def __aexit__(self, exc_type, exc_val, traceback) -> None:
+        try:
+            for context_item in reversed(context_var.get().values()):
+                if isinstance(context_item, ResourceContext):
+                    await context_item.tear_down()
+        finally:
+            context_var.reset(self._context_token)
 
 
 class DIContextMiddleware:

--- a/that_depends/providers/context_resources.py
+++ b/that_depends/providers/context_resources.py
@@ -22,21 +22,6 @@ Receive = typing.Callable[[], typing.Awaitable[Message]]
 Send = typing.Callable[[Message], typing.Awaitable[None]]
 ASGIApp = typing.Callable[[Scope, Receive, Send], typing.Awaitable[None]]
 
-"""
-@contextlib.asynccontextmanager
-async def container_context(initial_context: dict[str, typing.Any] | None = None) -> typing.AsyncIterator[None]:
-    token: typing.Final = context_var.set(initial_context or {})
-    try:
-        yield
-    finally:
-        try:
-            for context_item in reversed(context_var.get().values()):
-                if isinstance(context_item, ResourceContext):
-                    await context_item.tear_down()
-        finally:
-            context_var.reset(token)
-"""
-
 
 ContextType = dict[str, typing.Any]
 


### PR DESCRIPTION
@lesnik512 He is my suggested resolution for #72.

The idea: ``container_context`` is both an ``AsyncContextManager`` and a ``ContextManager``. 

**Resolution**:
When using ``async with container_context()`` one is able to resolve both ``sync`` and ``async`` context-resources.
When using ``with container_context()`` one is able to resolve only ``sync`` context-resources.


Example:
```python
def create_sync_resource() -> typing.Iterator[str]:
    value = uuid.uuid4().__str__()
    try:
        yield value
    finally:
        pass

async def create_async_resource() -> typing.AsyncIterator[str]:
    value = uuid.uuid4().__str__()
    try:
        yield value
    finally:
        pass


class DIContainer(BaseContainer):
    sync_context_resource = providers.ContextResource(create_sync_resource)
    async_context_resource = providers.ContextResource(create_async_resource)


@container_context()
@inject
def injected_sync_wrapped(s: str = Provide[DIContainer.sync_context_resource]) -> None:
    pass


@container_context()
@inject
async def injected_async_wrapped(s: str = Provide[DIContainer.async_context_resource]) -> None:
    pass


@inject
def injected_sync(s: str = Provide[DIContainer.sync_context_resource]) -> None:
    pass


@inject
async def injected_async(s: str = Provide[DIContainer.async_context_resource]) -> None:
    pass


async def main() -> None:
    async with container_context():
        injected_sync()
        await injected_async()
        with container_context():
            injected_sync()

    injected_sync_wrapped()
    await injected_async_wrapped()
```

**Implementation notes:**
I have implemented this with minimal changes to existing functionality. This brings with it the following behavior (which we can amend if you accept this approach).

Currently both ``container_context.__aenter__`` and ``container_context.__enter__`` create a ``ResourceContext``, however ``ResourceContext`` is unware of its creator (it doesn't know whether ``container_context`` is acting as a ``async`` or ``sync`` contextmanager). On resource resolution, the provider creates a ``Stack`` in the ``ResourceContext`` which is either a ``ExitStack`` or an ``AsyncExitStack`` depending on whether the ``ContextResource`` is ``async`` or ``sync``. Then, when exiting, the ``container_context`` tries to down the resources, but ``__exit__`` is only able to do so for ``sync`` resources since it is not able to call ``await stack.aclose()``. At this point we throw ``RuntimeException("Cannot tear down async context in sync mode")``.

Effect:
```python
async def main():
  with container_context():
        await injected_async()
  # Exception is raised when container_context exits, but resource is correctly created and used.
```
Of course, it would be better that we raise an ``Exception`` as soon as we attempt to resolve an ``async`` resource in a ``sync container_context()``, to do that we have to make the ``ResourceContext`` class aware of this. This is simple to do, I have just not done this in case you reject the general approach.

