### PR TITLE
#72 Prevent resolution of async resources in sync container_context.

### DIFF
--- a/docs/providers/context-resources.md
+++ b/docs/providers/context-resources.md
@@ -1,42 +1,97 @@
 # ContextResource
-- Context resources are resources with scoped lifecycle
-- Generator or async generator is required.
+
+Instances injected with the ``ContextResource`` provider have a managed lifecycle.
+
 ```python
-import typing
-
-import pytest
-
-from that_depends import BaseContainer, providers, container_context
-
-
-def create_sync_resource() -> typing.Iterator[str]:
-    # resource initialization
-    try:
-        yield "sync resource"
-    finally:
-        pass  # resource teardown
-
-
-async def create_async_resource() -> typing.AsyncIterator[str]:
-    # resource initialization
+async def my_async_resource() -> typing.AsyncIterator[str]
+    print("Initializing async resource")
     try:
         yield "async resource"
     finally:
-        pass  # resource teardown
+        print("Teardown of async resource")
 
+def my_sync_resource() -> typing.Iterator[str]
+    print("Initializing sync resource")
+    try:
+        yield "sync resource"
+    finally:
+        print("Teardown of sync resource")
 
-class DIContainer(BaseContainer):
-    context_resource = providers.ContextResource(create_sync_resource)
-    async_context_resource = providers.ContextResource(create_async_resource)
-
-
-async def main() -> None:
-    async with container_context():
-        # context resource can be resolved only inside of context
-        await DIContainer.context_resource.async_resolve()
-        await DIContainer.async_context_resource.async_resolve()
-    
-    # outside the context resolving will fail
-    with pytest.raises(RuntimeError, match="Context is not set. Use container_context"):
-        DIContainer.context_resource.sync_resolve()
+class MyContainer(BaseContainer):
+    async_resource = providers.ContextResource(my_async_resource)
+    sync_resource = providers.ContextResource(my_sync_resource)
 ```
+
+To be able to resolve a ``ContextResource`` one must first enter a ``container_context``:
+```python
+async with container_context():
+    await MyContainer.async_resource.async_resolve() # "async resource"
+    MyContainer.sync_resource.sync_resolve() # "sync resource"
+
+```
+
+ Trying to resolve a ``ContextResource`` without first entering ``container_context`` will yield an Exception:
+```python
+value = MyContainer.sync_resource.sync_resolve()
+ > RuntimeError: Context is not set. Use container_context
+```
+
+
+### Resolving async and sync dependencies:
+
+``container_context`` implements both ``AsyncContextManager`` and ``ContextManager``. This means that you can enter an async context with:
+
+```python
+async with container_context():
+    ...
+```
+An async context will allow resolution of both sync and async dependencies.
+
+
+A sync context can be entered using:
+
+```python
+with container_context():
+    ...
+```
+A sync context will only allow resolution of sync dependencies:
+```python
+async def my_func():
+    with container_context(): # enter sync context
+        # try to resolve async depenendency.
+        await MyContainer.async_resource.async_resolve()
+
+> RuntimeError: AsyncResource cannot be resolved in an sync context.
+```
+
+### Context Heirachy
+
+Each time you enter a ``container_context`` a new context is created in the background. Resouces are cached in the context after first resolution. Resources created in a context are torn down again when ``container_context`` exits.
+
+```python
+
+async with container_context():
+    value_outer = await MyContainer.resource.async_resolve()
+    async with container_context()
+        # new context -> resource will be resolved a new
+        value_inner = await MyContainer.resource.async_resolve()
+        assert value_inner != value_outer
+    # previously resolved value is cached in context.
+    assert value_outer == await MyContainer.resource.async_resolve()
+```
+
+
+
+
+### Resolving resources whenever a function is called
+
+``container_context`` can be used as a wrapper:
+
+```python
+
+@container_context()
+@inject
+async def insert_into_database(session = Provide[MyContainer.session]):
+    ...
+```
+Each time ``await insert_into_database()`` is called a new instance of ``session`` will be injected.

--- a/tests/providers/test_context_resources.py
+++ b/tests/providers/test_context_resources.py
@@ -7,6 +7,7 @@ import pytest
 
 from that_depends import BaseContainer, fetch_context_item, providers
 from that_depends.providers import container_context
+from that_depends.providers.base import ResourceContext
 
 
 logger = logging.getLogger(__name__)
@@ -46,6 +47,13 @@ async def _clear_di_container() -> typing.AsyncIterator[None]:
 def context_resource(request: pytest.FixtureRequest) -> providers.ContextResource[str]:
     return typing.cast(providers.ContextResource[str], request.param)
 
+@pytest.fixture
+def sync_context_resource() -> providers.ContextResource[str]:
+    return DIContainer.sync_context_resource
+
+@pytest.fixture
+def async_context_resource() -> providers.ContextResource[str]:
+    return DIContainer.async_context_resource
 
 async def test_context_resource_without_context_init(
     context_resource: providers.ContextResource[str],
@@ -63,6 +71,18 @@ async def test_context_resource(context_resource: providers.ContextResource[str]
 
     assert await context_resource() is context_resource_result
 
+@container_context()
+def test_sync_context_resource(sync_context_resource: providers.ContextResource[str]) -> None:
+    context_resource_result = sync_context_resource.sync_resolve()
+
+    assert sync_context_resource.sync_resolve() is context_resource_result
+    
+async def test_async_context_resource_in_sync_context(async_context_resource: providers.ContextResource[str]) -> None:
+    
+
+    with pytest.raises(RuntimeError, match="Cannot tear down async context in sync mode"):
+        with container_context():
+            await async_context_resource()
 
 async def test_context_resource_different_context(
     context_resource: providers.ContextResource[datetime.datetime],
@@ -122,3 +142,18 @@ async def test_context_resource_with_dynamic_resource() -> None:
 
     async with container_context():
         assert (await DIContainer.dynamic_context_resource()).startswith("sync")
+        
+
+
+async def test_early_exit_of_container_context() -> None:
+    with pytest.raises(RuntimeError, match="Context is not set, call ``__aenter__`` first"):
+        await container_context().__aexit__(None, None, None)
+    with pytest.raises(RuntimeError, match="Context is not set, call ``__enter__`` first"):
+        container_context().__exit__(None, None, None)
+
+
+async def test_resource_context_early_teardown() -> None:
+    context = ResourceContext()
+    assert context.context_stack is None
+    context.sync_tear_down()
+    assert context.context_stack is None

--- a/tests/providers/test_context_resources.py
+++ b/tests/providers/test_context_resources.py
@@ -47,13 +47,16 @@ async def _clear_di_container() -> typing.AsyncIterator[None]:
 def context_resource(request: pytest.FixtureRequest) -> providers.ContextResource[str]:
     return typing.cast(providers.ContextResource[str], request.param)
 
+
 @pytest.fixture
 def sync_context_resource() -> providers.ContextResource[str]:
     return DIContainer.sync_context_resource
 
+
 @pytest.fixture
 def async_context_resource() -> providers.ContextResource[str]:
     return DIContainer.async_context_resource
+
 
 async def test_context_resource_without_context_init(
     context_resource: providers.ContextResource[str],
@@ -71,18 +74,18 @@ async def test_context_resource(context_resource: providers.ContextResource[str]
 
     assert await context_resource() is context_resource_result
 
+
 @container_context()
 def test_sync_context_resource(sync_context_resource: providers.ContextResource[str]) -> None:
     context_resource_result = sync_context_resource.sync_resolve()
 
     assert sync_context_resource.sync_resolve() is context_resource_result
-    
-async def test_async_context_resource_in_sync_context(async_context_resource: providers.ContextResource[str]) -> None:
-    
 
-    with pytest.raises(RuntimeError, match="Cannot tear down async context in sync mode"):
-        with container_context():
-            await async_context_resource()
+
+async def test_async_context_resource_in_sync_context(async_context_resource: providers.ContextResource[str]) -> None:
+    with pytest.raises(RuntimeError, match="Cannot tear down async context in sync mode"), container_context():
+        await async_context_resource()
+
 
 async def test_context_resource_different_context(
     context_resource: providers.ContextResource[datetime.datetime],
@@ -142,7 +145,6 @@ async def test_context_resource_with_dynamic_resource() -> None:
 
     async with container_context():
         assert (await DIContainer.dynamic_context_resource()).startswith("sync")
-        
 
 
 async def test_early_exit_of_container_context() -> None:
@@ -153,7 +155,7 @@ async def test_early_exit_of_container_context() -> None:
 
 
 async def test_resource_context_early_teardown() -> None:
-    context = ResourceContext()
+    context: ResourceContext[str] = ResourceContext()
     assert context.context_stack is None
     context.sync_tear_down()
     assert context.context_stack is None

--- a/that_depends/providers/context_resources.py
+++ b/that_depends/providers/context_resources.py
@@ -1,9 +1,10 @@
 import contextlib
+from functools import wraps
 import logging
 import typing
 import uuid
 import warnings
-from contextvars import ContextVar
+from contextvars import ContextVar, Token
 
 from that_depends.providers.base import AbstractResource, ResourceContext
 
@@ -19,7 +20,7 @@ Receive = typing.Callable[[], typing.Awaitable[Message]]
 Send = typing.Callable[[Message], typing.Awaitable[None]]
 ASGIApp = typing.Callable[[Scope, Receive, Send], typing.Awaitable[None]]
 
-
+"""
 @contextlib.asynccontextmanager
 async def container_context(initial_context: dict[str, typing.Any] | None = None) -> typing.AsyncIterator[None]:
     token: typing.Final = context_var.set(initial_context or {})
@@ -32,6 +33,44 @@ async def container_context(initial_context: dict[str, typing.Any] | None = None
                     await context_item.tear_down()
         finally:
             context_var.reset(token)
+"""
+
+
+class AsyncContextDecorator(object):
+    "A base class or mixin that enables async context managers to work as decorators."
+
+    def _recreate_cm(self):
+        """Return a recreated instance of self.
+        """
+        return self
+
+    def __call__(self, func):
+        @wraps(func)
+        async def inner(*args, **kwds):
+            async with self._recreate_cm():
+                return await func(*args, **kwds)
+        return inner
+
+
+ContextType = typing.TypeVar("ContextType", bound=typing.Dict[str, typing.Any])
+class container_context(contextlib.AbstractAsyncContextManager[ContextType], AsyncContextDecorator):
+    def __init__(self, initial_context: typing.Optional[ContextType] = None) -> None:
+        
+        self._initial_context: typing.Final[ContextType] = initial_context
+        self._context_token: typing.Optional[Token[ContextType]] = None
+
+    async def __aenter__(self) -> ContextType:
+        self._context_token = context_var.set(self._initial_context or {})
+        return context_var.get()
+
+
+    async def __aexit__(self, exc_type, exc_val, traceback) -> None:
+        try:
+            for context_item in reversed(context_var.get().values()):
+                if isinstance(context_item, ResourceContext):
+                    await context_item.tear_down()
+        finally:
+            context_var.reset(self._context_token)
 
 
 class DIContextMiddleware:

--- a/that_depends/providers/context_resources.py
+++ b/that_depends/providers/context_resources.py
@@ -22,21 +22,6 @@ Receive = typing.Callable[[], typing.Awaitable[Message]]
 Send = typing.Callable[[Message], typing.Awaitable[None]]
 ASGIApp = typing.Callable[[Scope, Receive, Send], typing.Awaitable[None]]
 
-"""
-@contextlib.asynccontextmanager
-async def container_context(initial_context: dict[str, typing.Any] | None = None) -> typing.AsyncIterator[None]:
-    token: typing.Final = context_var.set(initial_context or {})
-    try:
-        yield
-    finally:
-        try:
-            for context_item in reversed(context_var.get().values()):
-                if isinstance(context_item, ResourceContext):
-                    await context_item.tear_down()
-        finally:
-            context_var.reset(token)
-"""
-
 
 ContextType = dict[str, typing.Any]
 

--- a/that_depends/providers/resources.py
+++ b/that_depends/providers/resources.py
@@ -25,7 +25,7 @@ class Resource(AbstractResource[T]):
         **kwargs: P.kwargs,
     ) -> None:
         super().__init__(creator, *args, **kwargs)
-        self._context: typing.Final[ResourceContext[T]] = ResourceContext()
+        self._context: typing.Final[ResourceContext[T]] = ResourceContext(is_async=self._is_async)
 
     def _fetch_context(self) -> ResourceContext[T]:
         return self._context


### PR DESCRIPTION
As mentioned in #85, currently an exception is only raised on ``__exit__`` of ``container_context()`` if an async ``ContextResource`` was resolved within the ``container_context`` (even if in otherwise async function).

Changed ``ResourceContext`` to store whether it was created in a sync or async ``container_context``. On resolution, async resources check if the ``ResourceContext`` is indeed async, if not, an exception is raised.

Also reworked the ``ContextResource`` documentation to reflect changes here an in #85.