### PR TITLE
Fixed AttrGetter bug with fastapi.

### DIFF
--- a/tests/integrations/test_fastapi_di.py
+++ b/tests/integrations/test_fastapi_di.py
@@ -27,10 +27,12 @@ async def read_root(
         container.SingletonFactory,
         fastapi.Depends(container.DIContainer.singleton),
     ],
+    singleton_attribute: typing.Annotated[bool, fastapi.Depends(container.DIContainer.singleton.dep1)],
 ) -> datetime.datetime:
     assert dependency.sync_resource == free_dependency.dependent_factory.sync_resource
     assert dependency.async_resource == free_dependency.dependent_factory.async_resource
-    assert singleton.dep1
+    assert singleton.dep1 is True
+    assert singleton_attribute is True
     return dependency.async_resource
 
 

--- a/tests/providers/test_attr_getter.py
+++ b/tests/providers/test_attr_getter.py
@@ -64,3 +64,12 @@ def test_nesting_levels(field_count: int, test_field_name: str, test_value: str 
 
     attr_value = _get_value_from_object_by_dotted_path(obj, attr_path)
     assert attr_value == test_value
+
+
+def test_attr_getter_with_invalid_attribute(some_settings_provider: providers.Singleton[Settings]) -> None:
+    with pytest.raises(AttributeError):
+        some_settings_provider.nested1_attr.nested2_attr.__some_private__  # noqa: B018
+    with pytest.raises(AttributeError):
+        some_settings_provider.nested1_attr.__another_private__  # noqa: B018
+    with pytest.raises(AttributeError):
+        some_settings_provider.nested1_attr._final_private_  # noqa: B018

--- a/that_depends/providers/attr_getter.py
+++ b/that_depends/providers/attr_getter.py
@@ -24,8 +24,7 @@ class AttrGetter(
 
     def __getattr__(self, attr: str) -> "AttrGetter[T]":
         if attr.startswith("_"):
-            msg = f"'{type(self)}' object has no attribute '{attr}'.\
-                Late resolution of attributes starting with `_` is not supported."
+            msg = f"'{type(self)}' object has no attribute '{attr}'"
             raise AttributeError(msg)
         self._attrs.append(attr)
         return self

--- a/that_depends/providers/attr_getter.py
+++ b/that_depends/providers/attr_getter.py
@@ -13,7 +13,9 @@ def _get_value_from_object_by_dotted_path(obj: typing.Any, path: str) -> typing.
     return attribute_getter(obj)
 
 
-class AttrGetter(AbstractProvider[T]):
+class AttrGetter(
+    AbstractProvider[T],
+):
     __slots__ = "_provider", "_attrs"
 
     def __init__(self, provider: AbstractProvider[T], attr_name: str) -> None:
@@ -21,6 +23,8 @@ class AttrGetter(AbstractProvider[T]):
         self._attrs = [attr_name]
 
     def __getattr__(self, attr: str) -> "AttrGetter[T]":
+        if attr.startswith("_"):
+            return self.__getattribute__(attr)
         self._attrs.append(attr)
         return self
 

--- a/that_depends/providers/attr_getter.py
+++ b/that_depends/providers/attr_getter.py
@@ -24,7 +24,9 @@ class AttrGetter(
 
     def __getattr__(self, attr: str) -> "AttrGetter[T]":
         if attr.startswith("_"):
-            return self.__getattribute__(attr)
+            msg = f"'{type(self)}' object has no attribute '{attr}'.\
+                Late resolution of attributes starting with `_` is not supported."
+            raise AttributeError(msg)
         self._attrs.append(attr)
         return self
 


### PR DESCRIPTION
Currently getting an attribute from a ``Singleton`` provider's attribute with ``fastapi.Depends`` raises the following exception:
```
line 2480, in _signature_from_callable
    raise TypeError(
TypeError: unexpected object <that_depends.providers.attr_getter.AttrGetter object at 0x000001D8C6D32D00> in __signature__ attribute
```

Here is an example to reproduce the exception in ``that_depends==1.19.1``:

```python
class Config(BaseModel):
    name: str = "test"


class MyContainer(BaseContainer):
    config = providers.Singleton(Config)

app = FastAPI()

@app.get("/config")
async def config(config: typing.Annotated[Config, Depends(MyContainer.config)]):
    return config # {"name": "test"}

@app.get("/config_attr")
async def config_attr(name: typing.Annotated[str, Depends(MyContainer.config.name)]):
    return name #  unexpected object <that_depends.providers.attr_getter.AttrGetter object at 0x000001F9954EED50> in __signature__ attribute

```


**Why does this happen?**
When we access an attribute of a provider instance, we get a ``AttrGetter`` instance which has the following ``__getattr__`` implementation:

```python
def __getattr__(self, attr: str) -> "AttrGetter[T]":
        self._attrs.append(attr)
        return self # <-- this line is key!
```
During the dependency resolution in ``fastapi.Depends`` tries to resolve the signature of the ``AttrGetter`` instance by calling ``inspect.signature(my_attr_getter)``. Within that call it also tries to resolve ``my_attr_getter.__signature__``, which , due to above implementation returns and instance of ``AttrGetter`` -> raising an exception.

**Possible solutions that do not work:**

1. Just handling the ``.__signature__`` case:
```python
def __getattr__(self, attr: str) -> "AttrGetter[T]":
        if attr == "__signature__":
            raise AttributeError()
        self._attrs.append(attr)
        return self
```
Does not work because during ``fastapi.Depends`` dependency resolution because the ``self._attrs`` list gets piled with ``__kwargs__``,``__random_stuff__`` etc.

2. Just handling attr starting with ``__``:
```python
def __getattr__(self, attr: str) -> "AttrGetter[T]":
        if attr.startswith("__"):
            raise AttributeError()
        self._attrs.append(attr)
        return self
```
Does not work because ``fastapi.Depends`` also calls ``my_attr_getter._partial``.

**Resolution:**
```python
def __getattr__(self, attr: str) -> "AttrGetter[T]":
        if attr.startswith("_"):
            raise AttributeError()
        self._attrs.append(attr)
        return self
```
Which of course prevents constructs such as 
```python
@app.get("/config_attr")
async def config_attr(name: typing.Annotated[str, Depends(MyContainer.config.name._some_private_attr)]):
    return name
```
But I would argue this is not the usual use case, nor would it be best practice.

**Long term solution:**

1. Rework ``AttrGetter`` and surrounding logic?
2. Create a custom ``fastapi`` intergration that does not mess with ``that_depends`` dependency resolution, similar to how it was done in ``dishka`` here: [dishka fastapi integration](https://github.com/reagento/dishka/blob/develop/src/dishka/integrations/fastapi.py).