### PR TITLE
Use PEP 735 `[dependency-groups]` for dev dependencies

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -5,13 +5,13 @@ install:
     uv sync --all-extras --frozen
 
 lint:
-    uv run ruff format .
-    uv run ruff check . --fix
+    uv run ruff format
+    uv run ruff check --fix
     uv run mypy .
 
 lint-ci:
-    uv run ruff format . --check
-    uv run ruff check . --no-fix
+    uv run ruff format --check
+    uv run ruff check --no-fix
     uv run mypy .
 
 test *args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ packages = [
 repository = "https://github.com/modern-python/that-depends"
 docs = "https://that-depends.readthedocs.io"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "fastapi",
     "litestar",
     "httpx",


### PR DESCRIPTION
uv recently released new version that supports now standardized `[dependency-groups]` table. See [uv 0.4.27](https://github.com/astral-sh/uv/releases/tag/0.4.27) and [PEP 735](https://peps.python.org/pep-0735/)