### PR TITLE
#109 Fix injecting into sync functions.

### DIFF
--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -64,15 +64,17 @@ def test_sync_injection(
     assert fixture_one == 1
 
 
-def test_wrong_sync_injection() -> None:
+def test_overriden_sync_injection() -> None:
     @inject
     def inner(
         _: container.SimpleFactory = Provide[container.DIContainer.simple_factory],
-    ) -> None:
+    ) -> container.SimpleFactory:
         """Do nothing."""
+        return _
 
-    with pytest.raises(RuntimeError, match="Injected arguments must not be redefined"):
-        inner(_=container.SimpleFactory(dep1="1", dep2=2))
+    factory = container.SimpleFactory(dep1="1", dep2=2)
+    with pytest.warns(RuntimeWarning, match="Expected injection, but nothing found. Remove @inject decorator."):
+        assert inner(_=factory) == factory
 
 
 def test_sync_empty_injection() -> None:

--- a/that_depends/injection.py
+++ b/that_depends/injection.py
@@ -56,13 +56,13 @@ def _inject_to_sync(
     @functools.wraps(func)
     def inner(*args: P.args, **kwargs: P.kwargs) -> T:
         injected = False
-        for field_name, field_value in signature.parameters.items():
+        for i, (field_name, field_value) in enumerate(signature.parameters.items()):
+            if i < len(args):
+                continue
             if not isinstance(field_value.default, AbstractProvider):
                 continue
             if field_name in kwargs:
-                msg = f"Injected arguments must not be redefined, {field_name=}"
-                raise RuntimeError(msg)
-
+                continue
             kwargs[field_name] = field_value.default.sync_resolve()
             injected = True
 


### PR DESCRIPTION
#109 Allow overriding dependencies when injecting into sync functions, such that the following code works:


```python
def sync_resource() -> str:
    return "resource"


class MyContainer(BaseContainer):
    sync_resource = providers.Factory(sync_resource)


@inject
def sync_function(provided: str = Provide[MyContainer.sync_resource]):
    return provided


def sync_main() -> None:
    assert sync_function() == "resource"

    # RuntimeError: Injected arguments must not be redefined, field_name='provided'
    assert sync_function(provided="overridden") == "overridden"

    # TypeError: my_function() got multiple values for argument 'provided'
    assert sync_function("overridden") == "overridden"


if __name__ == "__main__":
    sync_main()
```