### PR TITLE
docs: explain DI container teardown in pytest fixtures

### DIFF
--- a/docs/introduction/application-settings.md
+++ b/docs/introduction/application-settings.md
@@ -1,5 +1,7 @@
 # Application settings
+
 For example, you have application settings in `pydantic_settings`
+
 ```python
 import pydantic_settings
 
@@ -18,8 +20,7 @@ from that_depends import BaseContainer, providers
 
 class DIContainer(BaseContainer):
     settings = providers.Singleton(Settings)
-    settings_casted: Settings = settings.cast
-    some_factory = providers.Factory(SomeFactory, service_name=settings_casted.service_name)
+    some_factory = providers.Factory(SomeFactory, service_name=settings.cast.service_name)
 ```
 
 And when `some_factory` is resolved it will receive `service_name` attribute from `Settings`

--- a/docs/introduction/application-settings.md
+++ b/docs/introduction/application-settings.md
@@ -1,7 +1,5 @@
 # Application settings
-
 For example, you have application settings in `pydantic_settings`
-
 ```python
 import pydantic_settings
 

--- a/docs/providers/resources.md
+++ b/docs/providers/resources.md
@@ -1,10 +1,12 @@
 # Resource
+
 - resolve the dependency only once and cache the resolved instance for future injections;
 - unlike `Singleton` has finalization logic;
 - generator or async generator can be used;
 - context manager derived from `typing.ContextManager` or `typing.AsyncContextManager` can be used;
 
-# How it works
+## How it works
+
 ```python
 import typing
 
@@ -33,7 +35,9 @@ class MyContainer(BaseContainer):
 ```
 
 ## Concurrency safety
+
 `Resource` is safe to use in threading and asyncio concurrency:
+
 ```python
 # calling async_resolve concurrently in different coroutines will create only one instance
 await MyContainer.async_resource.async_resolve()

--- a/docs/providers/resources.md
+++ b/docs/providers/resources.md
@@ -33,9 +33,7 @@ class MyContainer(BaseContainer):
 ```
 
 ## Concurrency safety
-
 `Resource` is safe to use in threading and asyncio concurrency:
-
 ```python
 # calling async_resolve concurrently in different coroutines will create only one instance
 await MyContainer.async_resource.async_resolve()

--- a/docs/providers/resources.md
+++ b/docs/providers/resources.md
@@ -1,12 +1,10 @@
 # Resource
-
 - resolve the dependency only once and cache the resolved instance for future injections;
 - unlike `Singleton` has finalization logic;
 - generator or async generator can be used;
 - context manager derived from `typing.ContextManager` or `typing.AsyncContextManager` can be used;
 
 ## How it works
-
 ```python
 import typing
 

--- a/docs/testing/fixture.md
+++ b/docs/testing/fixture.md
@@ -1,0 +1,21 @@
+# Fixture
+
+## Dependencies teardown
+
+When using dependency injection in tests, it's important to properly tear down resources after tests complete.
+
+Without proper teardown, the Python event loop might close before resources have a chance to shut down properly, leading to errors like `RuntimeError: Event loop is closed`. This can happen because pytest closes the event loop after test completion, but any remaining open connections or resources might still try to perform cleanup operations.
+
+You can set up automatic teardown using a pytest fixture:
+
+```python
+import pytest_asyncio
+from typing import AsyncGenerator
+
+from my_project import DIContainer
+
+@pytest_asyncio.fixture(autouse=True)
+async def di_container_teardown() -> AsyncGenerator[None]:
+    yield
+    await DIContainer.tear_down()
+```

--- a/docs/testing/fixture.md
+++ b/docs/testing/fixture.md
@@ -4,7 +4,7 @@
 
 When using dependency injection in tests, it's important to properly tear down resources after tests complete.
 
-Without proper teardown, the Python event loop might close before resources have a chance to shut down properly, leading to errors like `RuntimeError: Event loop is closed`. This can happen because pytest closes the event loop after test completion, but any remaining open connections or resources might still try to perform cleanup operations.
+Without proper teardown, the Python event loop might close before resources have a chance to shut down properly, leading to errors like `RuntimeError: Event loop is closed`.
 
 You can set up automatic teardown using a pytest fixture:
 

--- a/docs/testing/fixture.md
+++ b/docs/testing/fixture.md
@@ -1,7 +1,5 @@
 # Fixture
-
 ## Dependencies teardown
-
 When using dependency injection in tests, it's important to properly tear down resources after tests complete.
 
 Without proper teardown, the Python event loop might close before resources have a chance to shut down properly, leading to errors like `RuntimeError: Event loop is closed`.
@@ -16,6 +14,8 @@ from my_project import DIContainer
 
 @pytest_asyncio.fixture(autouse=True)
 async def di_container_teardown() -> AsyncGenerator[None]:
-    yield
-    await DIContainer.tear_down()
+    try:
+        yield
+    finally:
+        await DIContainer.tear_down()
 ```


### PR DESCRIPTION
might be useful to others :)

edit: I just noticed you pretty much have the  same fixture https://github.com/modern-python/that-depends/blob/main/tests/conftest.py  