### PR TITLE
String provider resolution

### DIFF
--- a/tests/container.py
+++ b/tests/container.py
@@ -55,6 +55,7 @@ class SingletonFactory:
 
 class DIContainer(BaseContainer):
     default_scope = None
+    alias = "test_container"
     sync_resource = providers.Resource(create_sync_resource)
     async_resource = providers.Resource(create_async_resource)
 

--- a/tests/integrations/fastapi/test_fastapi_di_pass_request.py
+++ b/tests/integrations/fastapi/test_fastapi_di_pass_request.py
@@ -17,6 +17,7 @@ app = fastapi.FastAPI(dependencies=[fastapi.Depends(init_di_context)])
 
 
 class DIContainer(BaseContainer):
+    alias = "fastapi_container"
     context_request = providers.Factory(
         lambda: fetch_context_item("request"),
     )

--- a/tests/integrations/litestar/test_litestar_di.py
+++ b/tests/integrations/litestar/test_litestar_di.py
@@ -33,6 +33,7 @@ class SomeService:
 
 
 class DIContainer(BaseContainer):
+    alias = "litestar_container"
     bool_fn = providers.Factory(bool_fn, value=False)
     str_fn = providers.Factory(str_fn)
     list_fn = providers.Factory(list_fn)

--- a/tests/providers/test_collections.py
+++ b/tests/providers/test_collections.py
@@ -8,6 +8,7 @@ from that_depends.providers import AbstractProvider
 
 
 class DIContainer(BaseContainer):
+    alias = "collection_container"
     sync_resource = providers.Resource(create_sync_resource)
     async_resource = providers.Resource(create_async_resource)
     sequence = providers.List(sync_resource, async_resource)

--- a/tests/providers/test_context_resources.py
+++ b/tests/providers/test_context_resources.py
@@ -40,6 +40,7 @@ async def create_async_context_resource() -> typing.AsyncIterator[str]:
 
 
 class DIContainer(BaseContainer):
+    alias = "context_resource_container"
     default_scope = ContextScopes.ANY
     sync_context_resource = providers.ContextResource(create_sync_context_resource)
     async_context_resource = providers.ContextResource(create_async_context_resource)

--- a/tests/providers/test_inject_factories.py
+++ b/tests/providers/test_inject_factories.py
@@ -14,6 +14,7 @@ class InjectedFactories:
 
 
 class DIContainer(BaseContainer):
+    alias = "inject_factories_container"
     sync_resource = providers.Resource(container.create_sync_resource)
     async_resource = providers.Resource(container.create_async_resource)
 

--- a/tests/providers/test_object.py
+++ b/tests/providers/test_object.py
@@ -5,6 +5,7 @@ instance = "some string"
 
 
 class DIContainer(BaseContainer):
+    alias = "object_container"
     instance = providers.Object(instance)
 
 

--- a/tests/providers/test_resources.py
+++ b/tests/providers/test_resources.py
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 class DIContainer(BaseContainer):
+    alias = "resources_container"
     async_resource = providers.Resource(create_async_resource)
     sync_resource = providers.Resource(create_sync_resource)
     async_resource_from_class = providers.Resource(AsyncContextManagerResource)

--- a/tests/providers/test_selector.py
+++ b/tests/providers/test_selector.py
@@ -24,6 +24,7 @@ selector_state = SelectorState()
 
 
 class DIContainer(BaseContainer):
+    alias = "selector_container"
     sync_resource = providers.Resource(create_sync_resource)
     async_resource = providers.Resource(create_async_resource)
     selector: providers.Selector[datetime.datetime] = providers.Selector(

--- a/tests/providers/test_singleton.py
+++ b/tests/providers/test_singleton.py
@@ -36,6 +36,7 @@ def _sync_creator_with_dependency(dep: int) -> str:
 
 
 class DIContainer(BaseContainer):
+    alias = "singleton_container"
     factory: providers.AsyncFactory[int] = providers.AsyncFactory(_async_creator)
     settings: Settings = providers.Singleton(Settings).cast
     singleton = providers.Singleton(SingletonFactory, dep1=settings.some_setting)

--- a/tests/test_dynamic_container.py
+++ b/tests/test_dynamic_container.py
@@ -5,6 +5,7 @@ from that_depends import BaseContainer, providers
 
 
 class DIContainer(BaseContainer):
+    alias = "dynamic_container"
     sync_resource: providers.Resource[datetime.datetime]
     async_resource: providers.Resource[datetime.datetime]
 

--- a/tests/test_injection.py
+++ b/tests/test_injection.py
@@ -7,6 +7,7 @@ import pytest
 
 from tests import container
 from that_depends import BaseContainer, Provide, inject, providers
+from that_depends.injection import _validate_and_extract_provider_definition
 from that_depends.providers.context_resources import ContextScopes
 
 
@@ -140,3 +141,35 @@ async def test_sync_injection_with_scope() -> None:
 def test_inject_decorator_should_not_allow_any_scope() -> None:
     with pytest.raises(ValueError, match=f"{ContextScopes.ANY} is not allowed in inject decorator."):
         inject(scope=ContextScopes.ANY)
+
+
+@pytest.mark.parametrize(
+    ("definition", "expected"),
+    [
+        ("container.provider", ("container", "provider", [])),
+        ("container.provider.attr", ("container", "provider", ["attr"])),
+        ("container.provider.attr1.attr2", ("container", "provider", ["attr1", "attr2"])),
+        ("some.long.container.provider", ("some", "long", ["container", "provider"])),
+    ],
+)
+def test_validate_and_extract_provider_definition_valid(definition: str, expected: tuple[str, str, list[str]]) -> None:
+    """Test valid definitions and ensure the function returns the correct tuple."""
+    result = _validate_and_extract_provider_definition(definition)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "definition",
+    [
+        "",
+        "container",
+        ".provider",
+        "container.",
+        "container..provider",
+        "container.provider.",
+    ],
+)
+def test_validate_and_extract_provider_definition_invalid(definition: str) -> None:
+    """Test invalid definitions and ensure the function raises ValueError."""
+    with pytest.raises(ValueError, match=f"Invalid provider definition: {definition}"):
+        _validate_and_extract_provider_definition(definition)

--- a/that_depends/container.py
+++ b/that_depends/container.py
@@ -21,14 +21,10 @@ P = typing.ParamSpec("P")
 class BaseContainer(SupportsContext[None], metaclass=BaseContainerMeta):
     """Base container class."""
 
+    alias: str | None = None
     providers: dict[str, AbstractProvider[typing.Any]]
     containers: list[type["BaseContainer"]]
     default_scope: ContextScope | None = ContextScopes.ANY
-
-    @classmethod
-    def name(cls) -> str:
-        """Get container name."""
-        return cls.__name__
 
     @classmethod
     @overload

--- a/that_depends/container.py
+++ b/that_depends/container.py
@@ -26,6 +26,11 @@ class BaseContainer(SupportsContext[None], metaclass=BaseContainerMeta):
     default_scope: ContextScope | None = ContextScopes.ANY
 
     @classmethod
+    def name(cls) -> str:
+        """Get container name."""
+        return cls.__name__
+
+    @classmethod
     @overload
     def context(cls, func: typing.Callable[P, T]) -> typing.Callable[P, T]: ...
 

--- a/that_depends/injection.py
+++ b/that_depends/injection.py
@@ -115,10 +115,18 @@ async def _resolve_async(
     return await func(*args, **kwargs)
 
 
+def _get_provider_by_name(name: str) -> AbstractProvider[typing.Any]:
+    # CONTAINER_NAME.PROVIDER_NAME.ATTR.ATTR...ATRR
+
+    return name
+
+
 class ClassGetItemMeta(type):
     """Metaclass to support Provide[provider] syntax."""
 
-    def __getitem__(cls, provider: AbstractProvider[T]) -> T:
+    def __getitem__(cls, provider: AbstractProvider[T] | str) -> T | typing.Any:  # noqa: ANN401
+        if isinstance(provider, str):
+            return _get_provider_by_name(provider)
         return typing.cast(T, provider)
 
 

--- a/that_depends/meta.py
+++ b/that_depends/meta.py
@@ -35,9 +35,15 @@ class _ContainerMetaDict(dict[str, typing.Any]):
 class BaseContainerMeta(abc.ABCMeta):
     """Metaclass for BaseContainer."""
 
-    _instances: typing.ClassVar[list[type["BaseContainer"]]] = []
+    _instances: typing.ClassVar[dict[str, type["BaseContainer"]]] = {}
 
     _lock: Lock = Lock()
+
+    def name(cls) -> str:
+        """Get the name of the container class."""
+        if alias := getattr(cls, "alias", None):
+            return typing.cast(str, alias)
+        return cls.__name__
 
     @classmethod
     @override
@@ -47,12 +53,13 @@ class BaseContainerMeta(abc.ABCMeta):
     @override
     def __new__(cls, name: str, bases: tuple[type, ...], namespace: dict[str, typing.Any]) -> type:
         new_cls = super().__new__(cls, name, bases, namespace)
+        cls_name = new_cls.name()
         with cls._lock:
             if name != "BaseContainer":
-                cls._instances.append(new_cls)  # type: ignore[arg-type]
+                cls._instances[cls_name] = typing.cast(type["BaseContainer"], new_cls)
         return new_cls
 
     @classmethod
-    def get_instances(cls) -> list[type["BaseContainer"]]:
+    def get_instances(cls) -> dict[str, type["BaseContainer"]]:
         """Get all instances that inherit from BaseContainer."""
         return cls._instances

--- a/that_depends/providers/context_resources.py
+++ b/that_depends/providers/context_resources.py
@@ -466,9 +466,9 @@ class container_context(AbstractContextManager[ContextType], AbstractAsyncContex
             self._add_providers_from_containers(BaseContainerMeta.get_instances(), self._scope)
 
     def _add_providers_from_containers(
-        self, containers: list[ContainerType], scope: ContextScope | None = ContextScopes.ANY
+        self, containers: dict[str, ContainerType], scope: ContextScope | None = ContextScopes.ANY
     ) -> None:
-        for container in containers:
+        for container in containers.values():
             for container_provider in container.get_providers().values():
                 if isinstance(container_provider, ContextResource):
                     provider_scope = container_provider.get_scope()


### PR DESCRIPTION
## Proposed feature:

Allow dependency injection by specifying the container and provider using a string (does not require import).

```python

class MyContainer(BaseContainer):
    p = providers.Resource(creator)

@inject
def injected(value = Provide["MyContainer.p"]):
    return value

assert injected() = creator()
```

## Why?

- Resolving circular imports is annoying and sometimes unfeasible for large code-bases, one use of this can really help with this. This pattern is not only supported by other DI frameworks but also by libraries such as 'sqlalchemy`
- Technically allows hot swap of container (complete decoupling)

To be clear, I don't want to encourage this pattern as standard practice with `that-depends` but more an option that can help in certain scenarios such as #40.




