### PR TITLE
Allow Selectors to use other Providers and strings as selectors

### DIFF
--- a/docs/providers/selector.md
+++ b/docs/providers/selector.md
@@ -1,7 +1,10 @@
 # Selector
 
-- Selector provider chooses between a provider based on a key.
-- Resolves into a single dependency.
+The Selector provider chooses between provider based on a key. This resolves into a single dependency.
+
+The selector can be a callable that returns a string, an instance of `AbstractProvider` or a string.
+
+## Callable selectors
 
 ```python
 import os
@@ -20,6 +23,39 @@ class StorageServiceRemote(StorageService):
 class DIContainer(BaseContainer):
     storage_service = providers.Selector(
         lambda: os.getenv("STORAGE_BACKEND", "local"),
+        local=providers.Factory(StorageServiceLocal),
+        remote=providers.Factory(StorageServiceRemote),
+    )
+```
+
+## Provider selectors
+
+In this example, we have a Pydantic-Settings class that contains the key to select the provider.
+
+```python
+from typing import Literal
+from pydantic_settings import BaseSettings
+
+class Settings(BaseSettings):
+    storage_backend: Literal["local", "remote"] = "remote"
+
+class DIContainer(BaseContainer):
+    settings = providers.Singleton(Settings)
+    selector = providers.Selector(
+        settings.cast.storage_backend,
+        local=providers.Factory(StorageServiceLocal),
+        remote=providers.Factory(StorageServiceRemote),
+    )
+```
+
+## Fixed string selectors
+
+This can be useful for quickly testing.
+
+```python
+class DIContainer(BaseContainer):
+    selector = providers.Selector(
+        "local",
         local=providers.Factory(StorageServiceLocal),
         remote=providers.Factory(StorageServiceRemote),
     )

--- a/tests/providers/test_selector.py
+++ b/tests/providers/test_selector.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import typing
 
+import pydantic
 import pytest
 
 from tests.container import create_async_resource, create_sync_resource
@@ -74,3 +75,83 @@ async def test_selector_provider_overriding() -> None:
     selected = DIContainer.selector.sync_resolve()
     sync_resource = DIContainer.sync_resource.sync_resolve()
     assert selected == sync_resource
+
+
+class Settings(pydantic.BaseModel):
+    mode: typing.Literal["one", "two"] = "one"
+
+
+class SettingsSelectorContainer(BaseContainer):
+    settings = providers.Singleton(Settings)
+    operator = providers.Selector(
+        settings.cast.mode,
+        one=providers.Singleton(lambda: "Provider 1"),
+        two=providers.Singleton(lambda: "Provider 2"),
+    )
+
+
+async def test_selector_with_attrgetter_selector_sync() -> None:
+    assert SettingsSelectorContainer.settings.sync_resolve().mode == "one"
+    assert SettingsSelectorContainer.operator.sync_resolve() == "Provider 1"
+
+    SettingsSelectorContainer.settings.override(Settings(mode="two"))
+    assert SettingsSelectorContainer.settings.sync_resolve().mode == "two"
+    assert SettingsSelectorContainer.operator.sync_resolve() == "Provider 2"
+    SettingsSelectorContainer.settings.reset_override()
+
+
+async def test_selector_with_attrgetter_selector_async() -> None:
+    assert (await SettingsSelectorContainer.settings.async_resolve()).mode == "one"
+    assert (await SettingsSelectorContainer.operator.async_resolve()) == "Provider 1"
+
+    SettingsSelectorContainer.settings.override(Settings(mode="two"))
+    assert (await SettingsSelectorContainer.settings.async_resolve()).mode == "two"
+    assert (await SettingsSelectorContainer.operator.async_resolve()) == "Provider 2"
+    SettingsSelectorContainer.settings.reset_override()
+
+
+class StringSelectorContainer(BaseContainer):
+    selector = providers.Selector(
+        "one",
+        one=providers.Singleton(lambda: "Provider 1"),
+        two=providers.Singleton(lambda: "Provider 2"),
+    )
+
+
+async def test_selector_with_fixed_string() -> None:
+    assert StringSelectorContainer.selector.sync_resolve() == "Provider 1"
+    assert (await StringSelectorContainer.selector.async_resolve()) == "Provider 1"
+
+
+async def mode_one() -> str:
+    return "one"
+
+
+class StringProviderSelectorContainer(BaseContainer):
+    mode = providers.AsyncFactory(mode_one)
+    selector = providers.Selector(
+        mode.cast,
+        one=providers.Singleton(lambda: "Provider 1"),
+        two=providers.Singleton(lambda: "Provider 2"),
+    )
+
+
+async def test_selector_with_provider_selector_async() -> None:
+    assert (await StringProviderSelectorContainer.selector.async_resolve()) == "Provider 1"
+
+
+class NonStringProviderSelectorContainer(BaseContainer):
+    mode = providers.Singleton(lambda: {"foo": "bar"})
+    selector = providers.Selector(
+        mode.cast,  # type: ignore[arg-type]
+        one=providers.Singleton(lambda: "Provider 1"),
+        two=providers.Singleton(lambda: "Provider 2"),
+    )
+
+
+async def test_selector_with_non_string_provider() -> None:
+    with pytest.raises(TypeError, match="Invalid selector key type: <class 'dict'>, expected str"):
+        NonStringProviderSelectorContainer.selector.sync_resolve()
+
+    with pytest.raises(TypeError, match="Invalid selector key type: <class 'dict'>, expected str"):
+        await NonStringProviderSelectorContainer.selector.async_resolve()

--- a/tests/providers/test_selector.py
+++ b/tests/providers/test_selector.py
@@ -155,3 +155,23 @@ async def test_selector_with_non_string_provider() -> None:
 
     with pytest.raises(TypeError, match="Invalid selector key type: <class 'dict'>, expected str"):
         await NonStringProviderSelectorContainer.selector.async_resolve()
+
+
+class InvalidSelectorContainer(BaseContainer):
+    selector = providers.Selector(
+        None,  # type: ignore[arg-type]
+        one=providers.Singleton(lambda: "Provider 1"),
+        two=providers.Singleton(lambda: "Provider 2"),
+    )
+
+
+async def test_selector_with_invalid_selector() -> None:
+    with pytest.raises(
+        TypeError, match="Invalid selector type: <class 'NoneType'>, expected str, or a provider/callable returning str"
+    ):
+        InvalidSelectorContainer.selector.sync_resolve()
+
+    with pytest.raises(
+        TypeError, match="Invalid selector type: <class 'NoneType'>, expected str, or a provider/callable returning str"
+    ):
+        await InvalidSelectorContainer.selector.async_resolve()

--- a/that_depends/providers/selector.py
+++ b/that_depends/providers/selector.py
@@ -36,7 +36,9 @@ class Selector(AbstractProvider[T_co]):
 
     __slots__ = "_override", "_providers", "_selector"
 
-    def __init__(self, selector: str | typing.Callable[[], str], **providers: AbstractProvider[T_co]) -> None:
+    def __init__(
+        self, selector: typing.Callable[[], str] | AbstractProvider[str] | str, **providers: AbstractProvider[T_co]
+    ) -> None:
         """Initialize a new Selector instance.
 
         Args:


### PR DESCRIPTION
Hey that-depends team! This PR adds the ability to select providers based on other providers, or fixed strings.

For context, I was trying to switch between two providers based on an env-var, but using my Pydantic settings instance:

```python
class Container(BaseContainer):
    settings = Singleton(Settings)

    auth: Selector[Authenticator[User]] = Selector(
        settings.cast.auth_mode,
        jwt=AsyncFactory(build_jwt_user_authenticator, ...),
        fixed=AsyncFactory(build_fixed_authenticator),
    )
```

The selector needed to be a `callable -> str`, but I didn't particularly like resolving `Container.settings` outside of the container.

```
File ".../.venv/lib/python3.13/site-packages/fastapi/dependencies/utils.py", line 638, in solve_dependencies
  solved = await call(**solved_result.values)
File ".../.venv/lib/python3.13/site-packages/that_depends/providers/selector.py", line 76, in async_resolve
  raise RuntimeError(msg)
RuntimeError: No provider matches <coroutine object AbstractProvider.__call__ at 0x1104e7040>
.../.venv/lib/python3.13/site-packages/uvicorn/protocols/http/httptools_impl.py:418:
  RuntimeWarning: coroutine 'AbstractProvider.__call__' was never awaited
```

This changeset adds:
* Support for using an AbstractProvider, that returns a string, as a selector
    * I _think_ this could just be AttrGetter rather than allowing all Providers. However I'm guessing a use-case could be to set this more dynamically, e.g. from an async context resource. WDYT?
* Support for passing a string to selector, to enable quick stub-out tweaks.