### PR TITLE
Addressed some minor issues with selector.

### DIFF
--- a/tests/providers/test_selector.py
+++ b/tests/providers/test_selector.py
@@ -45,7 +45,7 @@ async def test_selector_provider_async() -> None:
 
 async def test_selector_provider_async_missing() -> None:
     selector_state.selector_state = "missing"
-    with pytest.raises(RuntimeError, match="No provider matches"):
+    with pytest.raises(KeyError, match="Key 'missing' not found in providers"):
         await DIContainer.selector()
 
 
@@ -59,7 +59,7 @@ async def test_selector_provider_sync() -> None:
 
 async def test_selector_provider_sync_missing() -> None:
     selector_state.selector_state = "missing"
-    with pytest.raises(RuntimeError, match="No provider matches"):
+    with pytest.raises(KeyError, match="Key 'missing' not found in providers"):
         DIContainer.selector.sync_resolve()
 
 
@@ -138,23 +138,6 @@ class StringProviderSelectorContainer(BaseContainer):
 
 async def test_selector_with_provider_selector_async() -> None:
     assert (await StringProviderSelectorContainer.selector.async_resolve()) == "Provider 1"
-
-
-class NonStringProviderSelectorContainer(BaseContainer):
-    mode = providers.Singleton(lambda: {"foo": "bar"})
-    selector = providers.Selector(
-        mode.cast,  # type: ignore[arg-type]
-        one=providers.Singleton(lambda: "Provider 1"),
-        two=providers.Singleton(lambda: "Provider 2"),
-    )
-
-
-async def test_selector_with_non_string_provider() -> None:
-    with pytest.raises(TypeError, match="Invalid selector key type: <class 'dict'>, expected str"):
-        NonStringProviderSelectorContainer.selector.sync_resolve()
-
-    with pytest.raises(TypeError, match="Invalid selector key type: <class 'dict'>, expected str"):
-        await NonStringProviderSelectorContainer.selector.async_resolve()
 
 
 class InvalidSelectorContainer(BaseContainer):


### PR DESCRIPTION
Minor changes to #164:

- Do not `isinstance` check that selector actually returns/gives a string, since users should adhere to the type hints.
- Changed a `RuntimeError` to a `KeyError`
- Removed `None` and `typing.Any` hints, had to concede 1 typing.cast instead.