### PR TITLE
fix: raise UserWarning when trying to wrap generators with container_context

### DIFF
--- a/docs/introduction/generator-injection.md
+++ b/docs/introduction/generator-injection.md
@@ -142,3 +142,15 @@ with container_context(scope=ContextScopes.REQUEST):
 Since no context initialization was needed, the generator will work as expected.
 
 1. Scope provided to `@inject` no longer matches scope of the `sync_provider`
+
+
+### Container Context
+
+Similarly to above, the `@container_context` also does **not** support generators:
+
+```python
+@container_context(Container)
+async def my_generator() -> typing.AsyncIterator[None]:
+    yield
+```
+The above code will raise a `UserWarning`.

--- a/tests/providers/test_context_resources.py
+++ b/tests/providers/test_context_resources.py
@@ -1113,3 +1113,19 @@ def test_context_scope_hash() -> None:
     assert ContextScope("TEST") == ContextScope("TEST")
     assert hash(ContextScope("YES")) != hash(ContextScope("NO"))
     assert hash(ContextScope("HMM")) == hash(ContextScope("HMM"))
+
+
+async def test_container_context_cannot_wrap_async_generator() -> None:
+    with pytest.raises(UserWarning):
+
+        @container_context(global_context={"key": "val"})
+        async def async_generator() -> typing.AsyncIterator[None]:
+            yield  # pragma: no cover
+
+
+def test_container_context_cannot_wrap_sync_generator() -> None:
+    with pytest.raises(UserWarning):
+
+        @container_context(global_context={"key": "val"})
+        def sync_generator() -> typing.Iterator[None]:
+            yield  # pragma: no cover

--- a/that_depends/providers/context_resources.py
+++ b/that_depends/providers/context_resources.py
@@ -612,6 +612,10 @@ class container_context(AbstractContextManager[ContextType], AbstractAsyncContex
             ```
 
         """
+        if inspect.isasyncgenfunction(func) or inspect.isgeneratorfunction(func):
+            msg = "@container_context cannot be used to wrap generators."
+            raise UserWarning(msg)
+
         if inspect.iscoroutinefunction(func):
 
             @wraps(func)


### PR DESCRIPTION
Makes the following raise a `UserWarning`

```python
@container_context(...)
async def my_generator(...):
    yield
```

Since `@container_context()` does not support generators.