### PR TITLE
docs: remove duplicated Ecosystem guidance (top callout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,6 @@
 
 Dependency injection framework for Python.
 
-> **Starting a new project?** Also consider
-> [`modern-di`](https://github.com/modern-python/modern-di), the newer DI framework from the
-> same author with a smaller core and per-framework integration packages.
-> `that-depends` remains fully supported — see [Ecosystem](#ecosystem) below.
-
 It is production-ready and gives you the following:
 - Simple async-first DI framework with IOC-container.
 - Python 3.10+ support.


### PR DESCRIPTION
The intro `> Starting a new project?` blockquote duplicated the modern-di
guidance already covered (more fully) by the `## Ecosystem` section. This
removes the redundant blockquote and keeps the Ecosystem section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)