### PR TITLE
docs: source download badge from pepy.tech to stop pypistats rate-limit errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/that-depends.svg)](https://pypi.org/project/that-depends/)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/that-depends.svg)](https://pypi.org/project/that-depends/)
-[![Downloads](https://img.shields.io/pypi/dm/that-depends.svg)](https://pypistats.org/packages/that-depends)
+[![Downloads](https://static.pepy.tech/badge/that-depends/month)](https://pepy.tech/projects/that-depends)
 [![Test Coverage](https://codecov.io/gh/modern-python/that-depends/branch/main/graph/badge.svg)](https://codecov.io/gh/modern-python/that-depends)
 [![CI](https://github.com/modern-python/that-depends/actions/workflows/ci.yml/badge.svg)](https://github.com/modern-python/that-depends/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/modern-python/that-depends.svg)](https://github.com/modern-python/that-depends/blob/main/LICENSE)


### PR DESCRIPTION
## Problem

The download badge used `img.shields.io/pypi/dm/<pkg>`, which shields.io sources from **pypistats.org**. pypistats rate-limits **by IP**, so the badge intermittently rendered **"rate limited by upstream service"** ([badges/shields#11620](https://github.com/badges/shields/issues/11620)).

## Change

- Image: `img.shields.io/pypi/dm/<pkg>.svg` -> `static.pepy.tech/badge/<pkg>/month`
- Link: `pypistats.org/packages/<pkg>` -> `pepy.tech/projects/<pkg>`

pepy serves statically cached SVGs from a different upstream. Metric stays **monthly downloads**. Mirrors the same fix already merged in `modern-di` (#250).

## Verification

- `static.pepy.tech/badge/<pkg>/month` returns HTTP 200 and renders a count.
- Docs-only change; no code or tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)