### PR TITLE
ci: publish to PyPI via Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,15 +5,21 @@ on:
     types:
       - published
 
+# contents: read for checkout; id-token: write for PyPI Trusted Publishing (OIDC).
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: pypi  # scopes the PyPI Trusted Publisher; hook for approval rules
     steps:
       - uses: actions/checkout@v6
       - uses: extractions/setup-just@v4
       - uses: astral-sh/setup-uv@v7
         with:
           cache-dependency-glob: "**/pyproject.toml"
+      # Auth via PyPI Trusted Publishing (OIDC); no PYPI_TOKEN. Needs a Trusted
+      # Publisher on the that-depends PyPI project (env: pypi, workflow: publish.yml).
       - run: just publish
-        env:
-          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}

--- a/Justfile
+++ b/Justfile
@@ -20,11 +20,12 @@ lint-ci:
 test *args:
     uv run --no-sync pytest {{ args }}
 
+# Auth via PyPI Trusted Publishing (OIDC); uv publish auto-detects the CI id-token.
 publish:
     rm -rf dist
     uv version $GITHUB_REF_NAME
     uv build
-    uv publish --token $PYPI_TOKEN
+    uv publish
 
 hook:
     uv run pre-commit install --install-hooks --overwrite


### PR DESCRIPTION
## What

Replace the long-lived `PYPI_TOKEN` secret with PyPI Trusted Publishing (OIDC) on `publish.yml`. The existing `on: release: published` trigger is unchanged.

## Changes

- `publish.yml`: add `permissions: { contents: read, id-token: write }`, run the `publish` job under a `pypi` environment, drop the `PYPI_TOKEN` env.
- `Justfile`: `uv publish --token $PYPI_TOKEN` -> `uv publish`.

## Why

No credential to leak or rotate; OIDC tokens are short-lived and scoped to this repo + workflow.

## Required before the next release (maintainer, PyPI-side)

1. PyPI -> that-depends project -> Publishing -> add a Trusted Publisher: owner `modern-python`, repo `that-depends`, **workflow `publish.yml`** (not release.yml), environment `pypi`.
2. Create the `pypi` environment under repo Settings -> Environments.
3. After the first OIDC release succeeds, delete the `PYPI_TOKEN` repo secret.

Cutting a release is unchanged: create a GitHub Release (tag) and `publish.yml` publishes via OIDC.