### PR TITLE
fix: LazyProvider no longer trigger eager module resolution

### DIFF
--- a/tests/experimental/test_lazy_provider.py
+++ b/tests/experimental/test_lazy_provider.py
@@ -1,5 +1,8 @@
+from unittest.mock import Mock
+
 import pytest
 
+from that_depends import providers
 from that_depends.experimental import LazyProvider
 
 
@@ -28,3 +31,21 @@ def test_lazy_provider_incorrect_import_string() -> None:
     p = LazyProvider("some.random.path")
     with pytest.raises(ImportError):
         p.resolve_sync()
+
+
+def test_lazy_provider_resolves_module_and_provider_strings() -> None:
+    p = LazyProvider(module_string="tests.experimental.test_container_2", provider_string="Container2.obj_2")
+
+    assert p.resolve_sync() == 2  # noqa: PLR2004
+
+
+def test_collection_registration_does_not_resolve_lazy_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    import_module_mock = Mock()
+    monkeypatch.setattr("that_depends.experimental.providers.importlib.import_module", import_module_mock)
+
+    lazy_provider = LazyProvider(module_string="some.module", provider_string="Container.provider")
+
+    providers.Dict(dep=lazy_provider)
+    providers.List(lazy_provider)
+
+    import_module_mock.assert_not_called()

--- a/that_depends/experimental/providers.py
+++ b/that_depends/experimental/providers.py
@@ -16,7 +16,7 @@ T_co = TypeVar("T_co", covariant=True)
 _IMPORT_STRING_REGEX = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*(\.[a-zA-Z_][a-zA-Z0-9_]*)*$")
 
 
-class LazyProvider(SupportsTeardown, SupportsContext[Any], AbstractProvider[Any]):
+class LazyProvider(AbstractProvider[Any], SupportsTeardown, SupportsContext[Any]):
     """Lazily imports and provides a provider from a module."""
 
     @overload
@@ -175,5 +175,8 @@ class LazyProvider(SupportsTeardown, SupportsContext[Any], AbstractProvider[Any]
 
     @typing_extensions.override
     def __getattr__(self, attr_name: str) -> typing.Any:
+        if attr_name.startswith("_"):
+            msg = f"'{type(self)}' object has no attribute '{attr_name}'"
+            raise AttributeError(msg)
         provider = self._get_provider()
         return getattr(provider, attr_name)


### PR DESCRIPTION
## Summary

Closes #222 

## Changes

Fixed inheritance order for `LazyProvider`

## Checklist

- [x] Lint and format pass (`ruff`)
- [x] Type check passes (`ty`)
- [x] Tests pass and new behavior is covered
- [x] Build succeeds (`uv build`) if packaging or build config changed
- [x] Docs updated if behavior or public API changed
- [x] Repo metadata stays consistent across the three surfaces (GitHub description, pyproject `description`, profile blurb) if this touches packaging
