### PR TITLE
docs: drop redundant title front matter on home page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,3 @@
----
-title: that-depends
----
-
 <div class="mp-hero" markdown>
 
 <h1 class="mp-lockup">


### PR DESCRIPTION
Follow-up to #225. The hero block's `title:` front matter made the browser tab read `that-depends - that-depends` (Material appends site_name). Removing it restores the bare `that-depends`. Home page nav label is unaffected (it comes from the `nav:` Quick-Start entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)