### PR TITLE
fix: invalidate type caches after rebinding

### DIFF
--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,4 +1,9 @@
-from that_depends import ContextScopes
+import typing
+
+import pytest
+
+from that_depends import BaseContainer, ContextScopes, providers
+from that_depends.exceptions import TypeNotBoundError
 from that_depends.meta import BaseContainerMeta
 
 
@@ -21,3 +26,18 @@ def test_base_container_meta_has_correct_default_name() -> None:
         pass
 
     assert _Test.name() == "_Test"
+
+
+def test_type_provider_cache_invalidates_after_rebinding() -> None:
+    provider = providers.Object(1).bind(int)
+
+    class Container(BaseContainer):
+        value = provider
+
+    assert Container.get_provider_for_type(int) is provider
+
+    provider.bind(str)
+
+    with pytest.raises(TypeNotBoundError):
+        Container.get_provider_for_type(int)
+    assert Container.get_provider_for_type(str) is typing.cast(providers.Object[str], provider)

--- a/that_depends/meta.py
+++ b/that_depends/meta.py
@@ -62,6 +62,7 @@ class BaseContainerMeta(abc.ABCMeta):
         "alias",
         "default_scope",
         "type_provider_cache",
+        "type_provider_cache_revision",
     )
 
     _lock: Lock = Lock()
@@ -133,8 +134,10 @@ class BaseContainerMeta(abc.ABCMeta):
             Provider for the given type.
 
         """
-        if not hasattr(cls, "type_provider_cache"):
+        current_revision = AbstractProvider._get_binding_revision()  # noqa: SLF001
+        if getattr(cls, "type_provider_cache_revision", -1) != current_revision:
             cls.type_provider_cache: dict[type[typing.Any], AbstractProvider[typing.Any]] = {}
+            cls.type_provider_cache_revision = current_revision
         if provider := cls.type_provider_cache.get(t):
             return typing.cast(AbstractProvider[T], provider)
         for provider in cls.get_providers().values():

--- a/that_depends/providers/base.py
+++ b/that_depends/providers/base.py
@@ -89,6 +89,9 @@ def _resolve_keyword_arguments_sync(
 class AbstractProvider(abc.ABC, typing.Generic[T_co]):
     """Base class for all providers."""
 
+    _binding_revision: typing.ClassVar[int] = 0
+    _binding_revision_lock: typing.ClassVar[threading.Lock] = threading.Lock()
+
     def __init__(self) -> None:
         """Create a new provider."""
         super().__init__()
@@ -115,9 +118,16 @@ class AbstractProvider(abc.ABC, typing.Generic[T_co]):
             The current provider instance.
 
         """
-        self._bindings = set(types)
-        self._has_contravariant_bindings = contravariant
+        with AbstractProvider._binding_revision_lock:
+            self._bindings = set(types)
+            self._has_contravariant_bindings = contravariant
+            AbstractProvider._binding_revision += 1
         return self
+
+    @classmethod
+    def _get_binding_revision(cls) -> int:
+        with AbstractProvider._binding_revision_lock:
+            return AbstractProvider._binding_revision
 
     def _register(self, candidates: typing.Iterable[typing.Any]) -> None:
         """Register current provider as child.


### PR DESCRIPTION
## Summary

Invalidate cached type-provider lookups after provider rebinding.

## Changes

- Added a process-wide binding revision protected by a lock.
- Lazily clear each container cache when its revision becomes stale.
- Added rebinding regression coverage.

## Checklist

- [x] Lint and format pass (`ruff`)
- [x] Tests pass and new behavior is covered
- [x] Build succeeds (`uv build`) if packaging or build config changed
- [x] Docs updated if behavior or public API changed
- [x] Repo metadata stays consistent across the three surfaces (GitHub description, pyproject `description`, profile blurb) if this touches packaging
