### PR TITLE
fix: raise for missing context keys

### DIFF
--- a/tests/providers/test_context_resources.py
+++ b/tests/providers/test_context_resources.py
@@ -1200,6 +1200,12 @@ def test_fetch_context_item_raises() -> None:
     with pytest.raises(KeyError):
         fetch_context_item("s", raise_on_not_found=True)
 
+    with container_context(global_context={"present": None}):
+        assert fetch_context_item("present", default="fallback") is None
+        with pytest.raises(KeyError, match="Key `missing` not found"):
+            fetch_context_item("missing", raise_on_not_found=True)
+        assert fetch_context_item("missing", default="fallback") == "fallback"
+
 
 def test_context_scope_hash() -> None:
     assert ContextScope("TEST") == ContextScope("TEST")

--- a/that_depends/providers/context_resources.py
+++ b/that_depends/providers/context_resources.py
@@ -241,8 +241,9 @@ def fetch_context_item(key: str, default: typing.Any = None, raise_on_not_found:
         ```
 
     """
-    if context := _get_container_context():
-        return context.get(key, default)
+    context = _get_container_context()
+    if context is not None and key in context:
+        return context[key]
     if raise_on_not_found:
         msg = f"Key `{key}` not found in global context."
         raise KeyError(msg)


### PR DESCRIPTION
## Summary

Make missing global-context keys raise consistently when requested.

## Changes
- Check key membership before returning a value.
- Preserve stored `None` values and caller defaults.
- Added non-empty-context missing-key regression coverage.

## Checklist

- [x] Lint and format pass (`ruff`)
- [x] Tests pass and new behavior is covered
- [x] Build succeeds (`uv build`) if packaging or build config changed
- [x] Docs updated if behavior or public API changed
- [x] Repo metadata stays consistent across the three surfaces (GitHub description, pyproject `description`, profile blurb) if this touches packaging
