### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,17 @@
 ## Summary
 
-<!-- What changes and why. Link the issue it closes, if any. -->
+<!-- What does this change and why? Link any related issue: Closes #123 -->
+
+## Changes
+
+<!-- Bullet the notable changes. -->
+-
 
 ## Checklist
 
-- [ ] `just lint-ci` passes (`ruff` format and check, `mypy`, `pyrefly`)
-- [ ] `just test` passes and new behavior is covered by tests
-- [ ] Docs updated if behavior or the public API changed
+- [ ] Lint and format pass (`ruff`)
+- [ ] Type check passes (`mypy` and `pyrefly`)
+- [ ] Tests pass and new behavior is covered
+- [ ] Build succeeds (`uv build`) if packaging or build config changed
+- [ ] Docs updated if behavior or public API changed
+- [ ] Repo metadata stays consistent across the three surfaces (GitHub description, pyproject `description`, profile blurb) if this touches packaging

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+## Summary
+
+<!-- What changes and why. Link the issue it closes, if any. -->
+
+## Checklist
+
+- [ ] `just lint-ci` passes (`ruff` format and check, `mypy`, `pyrefly`)
+- [ ] `just test` passes and new behavior is covered by tests
+- [ ] Docs updated if behavior or the public API changed


### PR DESCRIPTION
## Summary

Adds `.github/PULL_REQUEST_TEMPLATE.md`. The repo had no template, so PR checklists were written ad-hoc and could list tools this project does not use (e.g. `ty`, raised in #227).

The checklist now mirrors what CI actually runs:

- `just lint-ci` — `ruff format --check`, `ruff check`, `mypy`, `pyrefly`
- `just test` — pytest matrix
- docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)