### PR TITLE
chore: adopt ruff 0.16.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ ignore = [
     "COM812", # flake8-commas "Trailing comma missing"
     "ISC001", # flake8-implicit-str-concat
     "PT028", # Test function has default argument
+    "CPY001", # no per-file copyright header
 ]
 isort.lines-after-imports = 2
 isort.no-lines-before = ["standard-library", "local-folder"]


### PR DESCRIPTION
Fixes #235.

ruff 0.16.0 (2026-07-23) broke the scheduled dependency check:

- **CPY001** (`missing-copyright-notice`) left preview, so `select = ["ALL"]` now selects it — 70 hits. Ignored, matching the existing entry in `modern-di`.
- No Markdown reformatting needed in this repo.

Verified against ruff 0.15.22 (last week's green run): both `check` and `format` were clean, so every finding here is new in 0.16.0.

`just lint-ci` green locally; tests: 435 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)