### PR TITLE
fix: correct stale docs references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,10 +48,6 @@ sits inside the package directory, so it **ships in the wheel** and users get it
 the dependency. Treat it as public surface: a change to recommended usage, a renamed
 provider, or a new provider belongs there as well as in `docs/`.
 
-`.gitignore` ignores `.agents` at any depth. The existing `SKILL.md` is tracked, so it
-is unaffected, but a *new* file under `that_depends/.agents/` is invisible to
-`git add` — use `git add -f`.
-
 ## Architecture
 
 Every module under `that_depends/` is named for what it does; read it. What a

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -11,12 +11,12 @@ cd that-depends
 3. Install dependencies running `just install`
 
 ## Running linters
-`Ruff` and `mypy` are used for static analysis.
+`Ruff` is used for linting and formatting; `mypy` and `pyrefly` for type checking.
 
-Run all checks by command `just lint`
+Run all checks by command `just lint`. This rewrites files: use `just lint-ci` for a read-only run.
 
 ## Running tests
-Run all tests by command `just tests`
+Run all tests by command `just test`
 
 ## Building and running the documentation
 Host the documentation locally by running `just docs`

--- a/that_depends/.agents/skills/that-depends/SKILL.md
+++ b/that_depends/.agents/skills/that-depends/SKILL.md
@@ -68,7 +68,7 @@ This is the preferred style over explicit `resolve()` / `resolve_sync()` calls i
 | `Factory` / `AsyncFactory` | New value on each resolution |
 | `Resource` | Cached value with teardown |
 | `ContextResource` | Per-context / per-scope resource |
-| `Sequence` / `Mapping` | Aggregate multiple providers into read-only collection types |
+| `List` / `Dict` | Aggregate multiple providers into a read-only sequence or mapping |
 | `Selector` | Choose one provider from a key |
 | `State` | Pass runtime state through context |
 
@@ -236,7 +236,7 @@ async def di_teardown() -> AsyncIterator[None]:
 ## Notes on advanced features
 
 - `Generator` injection is supported, but generator injection cannot initialize `ContextResource` contexts for you. Pre-initialize the context first if needed.
-- `Selector`, `Sequence`, and `Mapping` help compose providers instead of manually wiring branches and aggregates in application code.
+- `Selector`, `List`, and `Dict` help compose providers instead of manually wiring branches and aggregates in application code.
 - `State` is useful for runtime values that should flow through provider resolution.
 - For framework integrations, see FastAPI, FastStream, and Litestar support in the docs.
 


### PR DESCRIPTION
## Summary

Follow-up to #238, which noted these while documenting the repo but deliberately left
them out of that diff.

Two places where documentation had drifted from the code it describes. The first is the
one that actually reaches users:

- **The shipped `SKILL.md` cheat sheet named `Sequence` and `Mapping` providers.** Those
  are the resolved *return* types; the exported providers are `List` and `Dict`. This
  file ships inside the wheel, so the wrong names arrive as installed guidance, not as a
  docs-site typo — and an agent reading the skill would write code against providers
  that do not exist.
- **`docs/dev/contributing.md` sent contributors to `just tests`**, which is not a recipe
  (it is `test`), so it failed on a new contributor's first run. The same page described
  static analysis as "Ruff and mypy", omitting `pyrefly`.

This also drops the `.agents` gitignore paragraph that #238 added to `AGENTS.md`. It was
inaccurate — it claimed the tracked `SKILL.md` was unaffected by the ignore rule, when
in fact `git add -u` and `git commit -a` work but an explicit `git add <path>` is
refused — and the accurate version is not worth the lines.

## Changes

- `that_depends/.agents/skills/that-depends/SKILL.md`: `Sequence`/`Mapping` → `List`/`Dict`, in the cheat sheet and the advanced-features note.
- `docs/dev/contributing.md`: `just tests` → `just test`; name `pyrefly`; note that `just lint` rewrites files and `lint-ci` does not.
- `AGENTS.md`: drop the `.agents` gitignore paragraph.

## Checklist

- [x] Lint and format pass (`ruff`)
- [x] Type check passes (`mypy` and `pyrefly`) — 70 source files, 0 errors
- [x] Tests pass and new behavior is covered — 456 passed, coverage stays at 100%; docs-only change, nothing new to cover
- [x] Build succeeds (`uv build`) if packaging or build config changed — n/a, no packaging change
- [x] Docs updated if behavior or public API changed — n/a; this *is* the docs correction, no API change
- [x] Repo metadata stays consistent across the three surfaces — n/a, not touched