### PR TITLE
chore(context7): drop the exclusion for a planning/ that never existed

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,4 @@
 {
   "url": "https://context7.com/modern-python/that-depends",
-  "public_key": "pk_sIP7B0JWZxstxUZb8L28N",
-  "excludeFolders": ["planning"]
+  "public_key": "pk_sIP7B0JWZxstxUZb8L28N"
 }


### PR DESCRIPTION
## Summary

`context7.json` excludes a `planning/` folder that this repo has never had. `bca21cf` added `"excludeFolders": ["planning"]` as part of an org-wide sweep, but `that-depends` never adopted the `planning/` convention — `git log --all -- planning` is empty, so the entry has excluded nothing since the day it landed. Related: the org-wide migration off that convention, modern-python/.github#67, which this repo is not part of.

Dropping the key rather than leaving an empty list, checked against Context7's published schema (https://context7.com/schema/context7.json) rather than assumed: the schema declares no root `required` array, so every property is optional, and `excludeFolders` carries `"default": []` with no `minItems`. An absent key and `[]` are equivalent to Context7, and absent matches the sibling repos that never carried the line.

Indexing behaviour is unchanged — the excluded path does not exist and never did. No other exclusion is touched; `planning` was the only entry.

## Changes

- `context7.json`: remove the `excludeFolders` key, leaving `url` and `public_key`.

## Checklist

- [x] Lint and format pass (`ruff`)
- [x] Type check passes (`mypy` and `pyrefly`)
- [x] Tests pass and new behavior is covered — `just test`: 456 passed, 100% coverage. No new behaviour to cover; this is index configuration, not code.
- [ ] Build succeeds (`uv build`) if packaging or build config changed — n/a, `context7.json` is not packaging config
- [ ] Docs updated if behavior or public API changed — n/a, no behaviour or API change
- [ ] Repo metadata stays consistent across the three surfaces — n/a, does not touch packaging