### PR TITLE
chore(ci): adopt the blocking offline link check

### DIFF
--- a/.github/workflows/_checks.yml
+++ b/.github/workflows/_checks.yml
@@ -46,3 +46,17 @@ jobs:
           files: ./coverage.xml
           flags: unittests
           name: codecov-${{ matrix.python-version }}
+
+  links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # --offline blocks network requests and excludes every external URL, so this gate
+      # is deterministic: it fails only on a relative link or file path a diff broke.
+      - name: Check local links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --offline
+            --no-progress
+            '**/*.md'


### PR DESCRIPTION
Adds the `links` job to `_checks.yml`, matching what every other repo in the org now runs. Part of modern-python/.github#66.

`--offline` blocks network requests and excludes external URLs rather than erroring on them, so the gate is deterministic: it fails only on a relative link or file path a diff broke. No exclusions, no token, no schedule, no cross-repo dependency.

**Why this repo needs it.** `mkdocs --strict` validates links *inside* `docs/` only — root Markdown, `.github/` and `docs/agents/` are unchecked today.

**Lands green.** Measured with the lychee container at this commit: `113 Total, 74 Unique, 36 OK, 0 Errors, 77 Excluded`.

### One known limitation of this gate

`--offline` *excludes* external URLs, so an absolute `https://github.com/modern-python/that-depends/blob/main/...` link pointing back at this repo is never checked. Relative links are the ones this catches.