### PR TITLE
docs(agents): drop the truth-home sentence from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,8 +98,7 @@ This repo has no `docs/adr/` and no `CONTEXT.md`. A decision that outlives the P
 in [`docs/dev/main-decisions.md`](docs/dev/main-decisions.md), which is a **user-facing
 page** — write it for a reader of the docs site, not as an internal record. Real work
 that is not scheduled becomes a GitHub issue on `modern-python/that-depends`
-(`gh issue create`). There is no third place, and no truth-home directory: behaviour is
-reviewed with the diff, not promoted to a page.
+(`gh issue create`).
 
 ## Releases
 


### PR DESCRIPTION
## Why

The fact-placement convention was dropped from `AGENTS.md` across the org (`lite-bootstrap` #188 and 23 sibling PRs). `that-depends` never carried the `Where a fact goes` section, so it was skipped — but it kept one sentence of the same doctrine:

> There is no third place, and no truth-home directory: behaviour is reviewed with the diff, not promoted to a page.

## Design

That sentence goes; nothing else in the paragraph changes. What stays is this repo's own arrangement, which is genuinely different from the sibling repos and is not the convention being dropped:

- no `docs/adr/` and no `CONTEXT.md`
- a decision that outlives the PR goes in [`docs/dev/main-decisions.md`](docs/dev/main-decisions.md), written as a **user-facing page** rather than an internal record
- unscheduled work becomes a GitHub issue

## Non-goals

No other change. This repo has no `Where a fact goes` section, no four-homes table and no ADR directory, so there is nothing else here to remove.
