### PR TITLE
docs: write README links absolute so they resolve on PyPI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,10 @@ Fill in [`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md). 
 this repo's own copy, kept local because it names `mypy` and `pyrefly`, and contributors
 do fill it in. Do not replace it with a free-form body, and do not edit the template.
 
+Every link in `README.md` must be absolute: `https://github.com/modern-python/<repo>/blob/main/<path>`,
+or `.../tree/main/<path>` for a directory. Never a relative path: `README.md` is also the PyPI long
+description, and PyPI does not rewrite relative links, so a relative one 404s on the package page.
+
 Unlike the rest of the org, **you are not the last reader of your diff** — a second
 party reviews and merges it. Write for them: what changed, why, and what you chose not
 to do. Keep one PR to one thing.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ want to move existing projects across.
 
 ## 📦 [PyPI](https://pypi.org/project/that-depends)
 
-## 📝 [License](LICENSE)
+## 📝 [License](https://github.com/modern-python/that-depends/blob/main/LICENSE)
 
 ## Part of `modern-python`
 


### PR DESCRIPTION
Implements modern-python/.github#85 for this repo.

## Why

`README.md` is this package's PyPI long description, and PyPI does not rewrite relative links: it
resolves them against `https://pypi.org/project/<name>/`. Relative links here therefore 404 on the
package page while resolving correctly in the checkout, which is why the offline link gate is green
on them and always has been. The gate answers a different question than the package page asks.

Verified against a live rendered PyPI page rather than inferred from renderer behaviour. Measured
org-wide, 23 of 25 published packages carry relative README links, all dead on their package pages.

## Design

Relative links become absolute `blob/main/` self-links, or `tree/main/` for a directory. The
`--remap` added in modern-python/.github#82 resolves those against the working tree, so the gate
keeps checking them rather than excluding them as external. Coverage is unchanged.

`main` rather than a release tag: a tag would stay correct in each frozen long description, but
modern-python/.github#82 deliberately excludes tag-pinned URLs from the gate, and writing the tag in
needs release-time substitution this repo does not have. `main` bounds the rot to old releases while
keeping every link checked.

The rule goes in `AGENTS.md` as an instruction rather than a test. `CLAUDE.md` imports `AGENTS.md`
here, so it is loaded into every agent turn, which makes it enforcement rather than documentation.
If a relative link appears in a README after this, that judgement is falsified and a test is the
answer. The `<repo>` placeholder keeps the paragraph byte-identical across all 25 repos.

## Non-goals

- No test or lint check enforces the rule
- No change to relative links outside `README.md`, which are correct and gate-checked
- Not applied to `.github` or the two templates, which publish no long description

## Verification

- No relative Markdown links remain in the README
- Offline link gate with this repo's remap: 0 errors
- Lint and tests are left to CI on this PR
