### PR TITLE
docs(agents): drop the retired paragraphs and keep the canonical ones verbatim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,9 +100,8 @@ work.
 
 This repo has no `docs/adr/` and no `CONTEXT.md`. A decision that outlives the PR goes
 in [`docs/dev/main-decisions.md`](docs/dev/main-decisions.md), which is a **user-facing
-page** — write it for a reader of the docs site, not as an internal record. Real work
-that is not scheduled becomes a GitHub issue on `modern-python/that-depends`
-(`gh issue create`).
+page** — write it for a reader of the docs site, not as an internal record. Issues live
+on `modern-python/that-depends` itself (`gh issue create`), not on the org repo.
 
 ## Releases
 


### PR DESCRIPTION
## Summary

Part of modern-python/.github#93. The three retired conventions are process notes the [standard](https://modern-python.org/standard/#9-repository-files) no longer carries, and section 9 fixes the two canonical `AGENTS.md` paragraphs word for word. Where a retired token appeared inside a sentence that states a real fact about this repo, the sentence is reworded rather than deleted, so the done-when grep in #93 comes back empty without losing the fact.

## Changes

- Removed: "Real work not scheduled becomes a GitHub issue".
- Reworded, not removed: the trailing sentence of the decisions paragraph loses the retired process note but keeps its fact: issues live on `modern-python/that-depends` itself, not on the org repo.

## Checklist

- [x] Lint and format pass (`ruff`) — Markdown only
- [x] Type check passes (`mypy` and `pyrefly`) — no Python changed
- [x] Tests pass and new behavior is covered — no behavior changed
- [x] Build succeeds (`uv build`) if packaging or build config changed — not touched
- [x] Docs updated if behavior or public API changed — this is the docs change
- [x] Repo metadata stays consistent across the three surfaces — not touched

